### PR TITLE
Correct input arguments when performing email token verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashlane-cli",
-    "version": "0.1",
+    "version": "0.1.0",
     "description": "Manage your Dashlane vault through a CLI tool",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/steps/performEmailTokenVerification.ts
+++ b/src/steps/performEmailTokenVerification.ts
@@ -17,5 +17,5 @@ export const performEmailTokenVerification =
         requestApi({
             path: 'authentication/PerformEmailTokenVerification',
             login: params.login,
-            payload: { login: params.login, token: params.token, activationFlow: false },
+            payload: { login: params.login, token: params.token },
         });


### PR DESCRIPTION
Current call to endpoint authentication/PerformEmailTokenVerification contains input argument `activationFlow`. This extra argument doesn't match the endpoint definition and an error 400 is returned.