### PR TITLE
Simplify search of passwords

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import { program } from 'commander';
 import winston from 'winston';
 import { sync } from './middleware/sync.js';
-import { getPassword } from './middleware/get.js';
+import { getPassword } from './middleware/getPasswords.js';
 import { connectAndPrepare } from './database/index.js';
 
 const debugLevel = process.argv.indexOf('--debug') !== -1 ? 'debug' : 'info';

--- a/src/middleware/sync.ts
+++ b/src/middleware/sync.ts
@@ -53,5 +53,5 @@ export const sync = async (params: Sync) => {
     Object.keys(latestContent.summary).forEach((key) => {
         summaryCounted[key] = Object.keys(latestContent.summary[key]).length;
     });
-    winston.debug(summaryCounted);
+    winston.debug(JSON.stringify(summaryCounted, null, 4));
 };


### PR DESCRIPTION
Share same behavior whether a filter is provided or not.
Transform password entries in JSON first to simplify the search and the future output in JSON format.
Correct a bug when the vault contained no passwords.
Insert index at the end of each password entry description to retrieve it without having to search again among the entries.

Note: It may be better to insert the index at the beginning like `<index>\t<title> - <email>`. Tell me!