### PR TITLE
feat(cli): add otp command and --print option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import { program } from 'commander';
 import winston from 'winston';
 import { sync } from './middleware/sync.js';
-import { getPassword } from './middleware/getPasswords.js';
+import { getOtp, getPassword } from './middleware/getPasswords.js';
 import { connectAndPrepare } from './database/index.js';
 
 const debugLevel = process.argv.indexOf('--debug') !== -1 ? 'debug' : 'info';
@@ -28,16 +28,33 @@ program
 
 program
     .command('password')
-    .description(
-        'Retrieve passwords from local vault and save it in the clipboard.\n' +
-            'Please provide the master password in the environment variable `MP`.'
-    )
+    .alias('p')
+    .description('Retrieve passwords from local vault and save it in the clipboard.')
+    .option('--print, -p', 'Prints just the password, instead of copying it inside the clipboard')
     .argument('[filter]', 'Filter passwords based on their title (usually the website)')
-    .action(async (filter: string | null) => {
+    .action(async (filter: string | null, options: { print: boolean }) => {
         const { db, deviceKeys } = await connectAndPrepare();
         await getPassword({
             titleFilter: filter,
             login: deviceKeys.login,
+            print: options.print,
+            db,
+        });
+        db.close();
+    });
+
+program
+    .command('otp')
+    .alias('o')
+    .description('Retrieve an OTP code from local vault and save it in the clipboard.')
+    .option('--print', 'Prints just the OTP code, instead of copying it inside the clipboard')
+    .argument('[filter]', 'Filter credentials based on their title (usually the website)')
+    .action(async (filter: string | null, options: { print: boolean }) => {
+        const { db, deviceKeys } = await connectAndPrepare();
+        await getOtp({
+            titleFilter: filter,
+            login: deviceKeys.login,
+            print: options.print,
             db,
         });
         db.close();


### PR DESCRIPTION
dcli otp lists only the credentials with an otp
<img width="626" alt="image" src="https://user-images.githubusercontent.com/4018426/163371945-772fc212-a7df-4481-87d8-84d5cd15a473.png">
<img width="677" alt="image" src="https://user-images.githubusercontent.com/4018426/163371994-701dcd57-000c-4395-911e-be076378d529.png">


The --print option, both on password on otp, prints only the otp/password.

<img width="573" alt="image" src="https://user-images.githubusercontent.com/4018426/163372722-6d6f5e0f-d15b-4f6d-b01b-04fe44c95b0d.png">

The goal is to use it in

`npm publish --otp $(dcli otp npm --print)`



Maybe the CLI commands are not ideal, we can discuss it later

(--export json/code/.. could be better, dcli get <otp/password/title...> google could also be better)