### PR TITLE
Correct bug when title parameter is missing from credentials

### DIFF
--- a/src/middleware/getPasswords.ts
+++ b/src/middleware/getPasswords.ts
@@ -108,7 +108,9 @@ export const getPassword = async (params: GetCredential): Promise<void> => {
     switch (params.output || 'clipboard') {
         case 'clipboard':
             clipboard.writeSync(selectedCredential.password);
-            console.log(`🔓 Password for "${selectedCredential.title || selectedCredential.url}" copied to clipboard!`);
+            console.log(
+                `🔓 Password for "${selectedCredential.title || selectedCredential.url || 'N\\C'}" copied to clipboard!`
+            );
 
             if (selectedCredential.otpSecret) {
                 const token = authenticator.generate(selectedCredential.otpSecret);

--- a/src/middleware/getPasswords.ts
+++ b/src/middleware/getPasswords.ts
@@ -108,7 +108,7 @@ export const getPassword = async (params: GetCredential): Promise<void> => {
     switch (params.output || 'clipboard') {
         case 'clipboard':
             clipboard.writeSync(selectedCredential.password);
-            console.log(`🔓 Password for "${selectedCredential.title}" copied to clipboard!`);
+            console.log(`🔓 Password for "${selectedCredential.title || selectedCredential.url}" copied to clipboard!`);
 
             if (selectedCredential.otpSecret) {
                 const token = authenticator.generate(selectedCredential.otpSecret);

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,7 +117,7 @@ export interface SecureNoteTransactionContent {
 }
 
 export interface VaultCredential {
-    title: string;
+    title?: string;
     email?: string;
     login?: string;
     password: string;
@@ -152,7 +152,7 @@ export class PrintableVaultCredential {
 
     toString(): string {
         return (
-            this.vaultCredential.title.trim() +
+            (this.vaultCredential.title?.trim() || this.vaultCredential.url) +
             ' - ' +
             (this.vaultCredential.email?.trim() ||
                 this.vaultCredential.login?.trim() ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,7 +152,7 @@ export class PrintableVaultCredential {
 
     toString(): string {
         return (
-            (this.vaultCredential.title?.trim() || this.vaultCredential.url) +
+            (this.vaultCredential.title?.trim() || this.vaultCredential.url || 'N\\C') +
             ' - ' +
             (this.vaultCredential.email?.trim() ||
                 this.vaultCredential.login?.trim() ||


### PR DESCRIPTION
Correct bug #42 that happens when the title parameter is missing from the credentials.
The fix is to use the url instead of the title parameter when the latest is missing. I believe it is reasonable to expect that at least one of the two parameters will be present.