### PR TITLE
feat(device-registration): migrate to GetAuthenticationMethodsForDevice endpoint

### DIFF
--- a/src/endpoints/getAuthenticationMethodsForDevice.ts
+++ b/src/endpoints/getAuthenticationMethodsForDevice.ts
@@ -1,0 +1,60 @@
+import { requestApi } from '../requestApi';
+
+type SupportedAuthenticationMethod = 'email_token' | 'totp' | 'duo_push' | 'dashlane_authenticator';
+
+const defaultSupportedMethods: SupportedAuthenticationMethod[] = [
+    'email_token',
+    'totp',
+    'duo_push',
+    'dashlane_authenticator',
+];
+
+interface GetAuthenticationMethodsForDeviceParams {
+    login: string;
+    supportedMethods?: SupportedAuthenticationMethod[];
+}
+
+interface GetAuthenticationMethodsForDeviceResult {
+    /** The authentication methods available for the user */
+    verifications: (
+        | {
+              type: 'sso';
+              ssoInfo: {
+                  serviceProviderUrl: string;
+                  migration?: 'sso_member_to_admin' | 'mp_user_to_sso_member' | 'sso_member_to_mp_user';
+                  /** This flag will be set to true if the service provider is using Nitro enclaves */
+                  isNitroProvider?: boolean;
+              };
+          }
+        | {
+              type: 'email_token' | 'totp' | 'duo_push' | 'dashlane_authenticator';
+          }
+        | {
+              type: 'u2f';
+              challenges?: {
+                  challenge: string;
+                  version: string;
+                  appId: string;
+                  keyHandle: string;
+              }[];
+          }
+    )[];
+}
+
+// Unused for now
+export type GetAuthenticationMethodsForDeviceError =
+    | 'user_not_found'
+    | 'SSO_BLOCKED'
+    | 'WRONG_SSO_STATUS_TO_MIGRATE'
+    | 'CLIENT_VERSION_DOES_NOT_SUPPORT_SSO_MIGRATION'
+    | 'expired_version';
+
+export const getAuthenticationMethodsForDevice = ({
+    login,
+    supportedMethods = defaultSupportedMethods,
+}: GetAuthenticationMethodsForDeviceParams) =>
+    requestApi<GetAuthenticationMethodsForDeviceResult>({
+        path: 'authentication/GetAuthenticationMethodsForDevice',
+        login,
+        payload: { login, methods: supportedMethods },
+    });

--- a/src/endpoints/requestDeviceRegistration.ts
+++ b/src/endpoints/requestDeviceRegistration.ts
@@ -34,7 +34,9 @@ export interface RequestDeviceRegistrationOutput {
           }
     )[];
 }
-
+/**
+ * @deprecated Use getAuthenticationMethodsForDevice
+ */
 export const requestDeviceRegistration = (params: RequestDeviceRegistration) =>
     requestApi<RequestDeviceRegistrationOutput>({
         path: 'authentication/RequestDeviceRegistration',

--- a/src/endpoints/requestEmailTokenVerification.ts
+++ b/src/endpoints/requestEmailTokenVerification.ts
@@ -1,0 +1,17 @@
+import { requestApi } from '../requestApi';
+
+interface RequestEmailTokenVerificationParams {
+    login: string;
+}
+
+type RequestEmailTokenVerificationResult = any;
+
+// Unused for now
+export type RequestEmailTokenVerificationError = 'TWOFA_EMAIL_TOKEN_NOT_ENABLED' | 'invalid_authentication';
+
+export const requestEmailTokenVerification = ({ login }: RequestEmailTokenVerificationParams) =>
+    requestApi<RequestEmailTokenVerificationResult>({
+        path: 'authentication/RequestEmailTokenVerification',
+        login,
+        payload: { login },
+    });

--- a/src/middleware/registerDevice.ts
+++ b/src/middleware/registerDevice.ts
@@ -6,9 +6,10 @@ import {
     performDuoPushVerification,
     performEmailTokenVerification,
     performTotpVerification,
-    requestDeviceRegistration,
 } from '../endpoints';
 import { askOtp, askToken } from '../utils';
+import { getAuthenticationMethodsForDevice } from '../endpoints/getAuthenticationMethodsForDevice';
+import { requestEmailTokenVerification } from '../endpoints/requestEmailTokenVerification';
 
 interface RegisterDevice {
     login: string;
@@ -19,27 +20,30 @@ export const registerDevice = async (params: RegisterDevice): Promise<CompleteDe
     winston.debug('Registering the device...');
 
     // Log in via a compatible verification method
-    const { verification } = await requestDeviceRegistration({ login });
+    const { verifications } = await getAuthenticationMethodsForDevice({ login });
 
     let authTicket: string;
-    if (verification.find((method) => method.type === 'duo_push')) {
+    if (verifications.find((method) => method.type === 'duo_push')) {
         ({ authTicket } = await performDuoPushVerification({ login }));
-    } else if (verification.find((method) => method.type === 'dashlane_authenticator')) {
+    } else if (verifications.find((method) => method.type === 'dashlane_authenticator')) {
         ({ authTicket } = await performDashlaneAuthenticatorVerification({ login }));
-    } else if (verification.find((method) => method.type === 'totp')) {
-        const otp = askOtp();
+    } else if (verifications.find((method) => method.type === 'totp')) {
+        const otp = await askOtp();
+
         ({ authTicket } = await performTotpVerification({
             login,
             otp: String(otp).padStart(5, '0'),
         }));
-    } else if (verification.find((method) => method.type === 'email_token')) {
-        const token = askToken();
+    } else if (verifications.find((method) => method.type === 'email_token')) {
+        await requestEmailTokenVerification({ login });
+
+        const token = await askToken();
         ({ authTicket } = await performEmailTokenVerification({
             login,
             token: String(token).padStart(5, '0'),
         }));
     } else {
-        throw new Error('Auth verification method not supported: ' + verification[0].type);
+        throw new Error('Auth verification method not supported: ' + verifications[0].type);
     }
 
     // Complete the device registration and save the result


### PR DESCRIPTION
This should fix #41 .
I was able to login using an email token, as well as OTP1.

Note that the behaviour for email_token device registration seems to have changed from the previous endpoint, and we now need to explicitly request the server to send an email token.

Also, I was unable to login using OTP2. But this is repro on master. I'll try to investigate and open a bugfix soon.