### PR TITLE
Correctly handle password retrieval when no filters are provided

### DIFF
--- a/src/middleware/getPasswords.ts
+++ b/src/middleware/getPasswords.ts
@@ -52,7 +52,7 @@ export const selectCredentials = async (params: GetCredential): Promise<VaultCre
     );
 
     let matchedCredentials = beautifiedCredentials;
-    if (filters) {
+    if (filters?.length) {
         interface ItemFilter {
             keys: string[];
             value: string;


### PR DESCRIPTION
This PR solves issue #83.

Since the addition of the filters feature for credentials retrieving in #56, the `dcli password` command accepts an optional list of filters as arguments.
If no filters are applied, the filtering process should be skipped.

However, in JavaScript, `[]` evaluates to `true`. Then, if no filters were specified, the output list of matching credentials was always empty.