### PR TITLE
Correct the message when retrieving credentials without specifying filters

### DIFF
--- a/src/middleware/getPasswords.ts
+++ b/src/middleware/getPasswords.ts
@@ -99,7 +99,7 @@ export const selectCredential = async (params: GetCredential, onlyOtpCredentials
         return matchedCredentials[0];
     }
 
-    return askCredentialChoice({ matchedCredentials, hasFilters: Boolean(params.filters) });
+    return askCredentialChoice({ matchedCredentials, hasFilters: Boolean(params.filters?.length) });
 };
 
 export const getPassword = async (params: GetCredential): Promise<void> => {


### PR DESCRIPTION
Following #84, the message displayed is not the right one when no filters are provided while retrieving credentials.

I believe there are no other occurrences of this issue.