### PR TITLE
Bring filters & JSON output to `note`, add support for new `-1, --one` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ dcli otp [filters]
 In order to **get a secure note**:
 
 ```sh
-dcli note [titleFilter]
+dcli note [filters]
 ```
 
 ### Options

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,16 +112,18 @@ program
         'How to print the notes among `text, json`. The JSON option outputs all the matching notes',
         'text'
     )
+    .option('-1, --one', 'Returns the matching note only if a single one matches, errors out otherwise')
     .argument(
         '[filters...]',
         'Filter notes based on any parameter using <param>=<value>; if <param> is not specified in the filter, will default to title only'
     )
-    .action(async (filters: string[] | null, options: { output: string | null }) => {
+    .action(async (filters: string[] | null, options: { output: string | null, one: Boolean }) => {
         const { db, secrets } = await connectAndPrepare({});
         await getNote({
             filters,
             secrets,
             output: options.output,
+            one: options.one,
             db,
         });
         db.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,34 +52,20 @@ program
         'How to print the passwords among `clipboard, password, json`. The JSON option outputs all the matching credentials',
         'clipboard'
     )
+    .option('-1, --one', 'Returns the matching credential only if a single one matches, errors out otherwise')
     .argument(
         '[filters...]',
         'Filter credentials based on any parameter using <param>=<value>; if <param> is not specified in the filter, will default to url and title'
     )
-    .action(async (filters: string[] | null, options: { output: string | null }) => {
+    .action(async (filters: string[] | null, options: { output: string | null, one: Boolean }) => {
         const { db, secrets } = await connectAndPrepare({});
-
-        if (options.output === 'json') {
-            console.log(
-                JSON.stringify(
-                    await selectCredentials({
-                        filters,
-                        secrets,
-                        output: options.output,
-                        db,
-                    }),
-                    null,
-                    4
-                )
-            );
-        } else {
-            await getPassword({
-                filters,
-                secrets,
-                output: options.output,
-                db,
-            });
-        }
+        await getPassword({
+            filters,
+            secrets,
+            output: options.output,
+            one: options.one,
+            db,
+        });
         db.close();
     });
 
@@ -88,16 +74,18 @@ program
     .alias('o')
     .description('Retrieve an OTP code from local vault and copy it to the clipboard')
     .option('--print', 'Prints just the OTP code, instead of copying it to the clipboard')
+    .option('-1, --one', 'Returns the matching credential only if a single one matches, errors out otherwise')
     .argument(
         '[filters...]',
         'Filter credentials based on any parameter using <param>=<value>; if <param> is not specified in the filter, will default to url and title'
     )
-    .action(async (filters: string[] | null, options: { print: boolean }) => {
+    .action(async (filters: string[] | null, options: { print: boolean, one: Boolean }) => {
         const { db, secrets } = await connectAndPrepare({});
         await getOtp({
             filters,
             secrets,
             output: options.print ? 'otp' : 'clipboard',
+            one: options.one,
             db,
         });
         db.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import { Secrets } from './types';
 import { connect } from './database/connect';
 import {
     sync,
-    selectCredentials,
     getOtp,
     getNote,
     getPassword,
@@ -57,7 +56,7 @@ program
         '[filters...]',
         'Filter credentials based on any parameter using <param>=<value>; if <param> is not specified in the filter, will default to url and title'
     )
-    .action(async (filters: string[] | null, options: { output: string | null, one: Boolean }) => {
+    .action(async (filters: string[] | null, options: { output: string | null, one: boolean }) => {
         const { db, secrets } = await connectAndPrepare({});
         await getPassword({
             filters,
@@ -79,7 +78,7 @@ program
         '[filters...]',
         'Filter credentials based on any parameter using <param>=<value>; if <param> is not specified in the filter, will default to url and title'
     )
-    .action(async (filters: string[] | null, options: { print: boolean, one: Boolean }) => {
+    .action(async (filters: string[] | null, options: { print: boolean, one: boolean }) => {
         const { db, secrets } = await connectAndPrepare({});
         await getOtp({
             filters,
@@ -105,7 +104,7 @@ program
         '[filters...]',
         'Filter notes based on any parameter using <param>=<value>; if <param> is not specified in the filter, will default to title only'
     )
-    .action(async (filters: string[] | null, options: { output: string | null, one: Boolean }) => {
+    .action(async (filters: string[] | null, options: { output: string | null, one: boolean }) => {
         const { db, secrets } = await connectAndPrepare({});
         await getNote({
             filters,

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,12 +107,21 @@ program
     .command('note')
     .alias('n')
     .description('Retrieve a secure note from the local vault and open it')
-    .argument('[filter]', 'Filter notes based on their title')
-    .action(async (filter: string | null) => {
+    .option(
+        '-o, --output <type>',
+        'How to print the notes among `text, json`. The JSON option outputs all the matching notes',
+        'text'
+    )
+    .argument(
+        '[filters...]',
+        'Filter notes based on any parameter using <param>=<value>; if <param> is not specified in the filter, will default to title only'
+    )
+    .action(async (filters: string[] | null, options: { output: string | null }) => {
         const { db, secrets } = await connectAndPrepare({});
         await getNote({
-            titleFilter: filter,
+            filters,
             secrets,
+            output: options.output,
             db,
         });
         db.close();

--- a/src/middleware/getSecureNotes.ts
+++ b/src/middleware/getSecureNotes.ts
@@ -8,6 +8,7 @@ interface GetSecureNote {
     filters: string[] | null;
     secrets: Secrets;
     output: string | null;
+    one: Boolean;
     db: Database.Database;
 }
 
@@ -28,7 +29,7 @@ const decryptSecureNotesTransactions = async (
 };
 
 export const getNote = async (params: GetSecureNote): Promise<void> => {
-    const { secrets, filters, db, output } = params;
+    const { secrets, filters, db, output, one } = params;
 
     winston.debug(`Retrieving: ${filters && filters.length > 0 ? filters.join(' ') : ''}`);
     const transactions = db
@@ -82,9 +83,20 @@ export const getNote = async (params: GetSecureNote): Promise<void> => {
         );
     }
 
+    if (one && matchedNotes?.length !== 1) {
+        throw new Error('Matched ' + (matchedNotes?.length || 0) + ' notes, required exactly one match.');
+    }
+
     switch (output || 'text') {
         case 'json':
-            console.log(JSON.stringify(matchedNotes, null, 4));
+            let outputNotes;
+            if (one && matchedNotes) {
+                outputNotes = matchedNotes[0];
+            } else {
+                outputNotes = matchedNotes;
+            }
+
+            console.log(JSON.stringify(outputNotes, null, 4));
             break;
         case 'text':
             let selectedNote: VaultNote | null = null;

--- a/src/middleware/utils.ts
+++ b/src/middleware/utils.ts
@@ -1,0 +1,47 @@
+export const filterMatches = async <VaultType>(
+    values: VaultType[] | undefined,
+    filters: string[] | null,
+    defaultMatch: string[] = ['url', 'title'],
+): Promise<VaultType[]> => {
+    if (!values) {
+        return [] as VaultType[];
+    }
+
+    let matches = values;
+
+    if (filters?.length) {
+        interface ItemFilter {
+            keys: string[];
+            value: string;
+        }
+        const parsedFilters: ItemFilter[] = [];
+
+        filters.forEach((filter) => {
+            const [splitFilterKey, ...splitFilterValues] = filter.split('=');
+
+            const filterValue = splitFilterValues.join('=') || splitFilterKey;
+            const filterKeys = splitFilterValues.length > 0 ? splitFilterKey.split(',') : defaultMatch;
+
+            const canonicalFilterValue = filterValue.toLowerCase();
+
+            parsedFilters.push({
+                keys: filterKeys,
+                value: canonicalFilterValue,
+            });
+        });
+
+        matches = matches?.filter((item) =>
+            parsedFilters
+                .map((filter) =>
+                    filter.keys.map((key) => {
+                        const val = item[key as keyof VaultType];
+                        return typeof val === 'string' && val.toLowerCase().includes(filter.value);
+                    })
+                )
+                .flat()
+                .some((b) => b)
+        );
+    }
+
+    return matches;
+}

--- a/src/middleware/utils.ts
+++ b/src/middleware/utils.ts
@@ -1,8 +1,8 @@
-export const filterMatches = async <VaultType>(
+export const filterMatches = <VaultType>(
     values: VaultType[] | undefined,
     filters: string[] | null,
     defaultMatch: string[] = ['url', 'title'],
-): Promise<VaultType[]> => {
+): VaultType[] => {
     if (!values) {
         return [] as VaultType[];
     }


### PR DESCRIPTION
As the title states, this brings:
- `dcli note` support for better filters (as was done for `password` before)
- `dcli note` support for `--output json`
- `dcli note` support for `--one` (`-1`), which will error out if the matches are not exactly one entry
- `dcli password` support for `--one` (`-1`), which will error out if the matches are not exactly one entry