### PR TITLE
Add team device support 2

### DIFF
--- a/src/endpoints/getTeamMembers.ts
+++ b/src/endpoints/getTeamMembers.ts
@@ -1,23 +1,21 @@
-import { Secrets } from '../types';
-import { requestUserApi } from '../requestApi';
+import { TeamDeviceCredentials } from '../types';
+import { requestTeamApi } from '../requestApi';
 
 interface GetTeamMembersParams {
-    teamId: number;
-    secrets: Secrets;
+    teamDeviceCredentials: TeamDeviceCredentials;
     page: number;
     limit: number;
 }
 
 export const getTeamMembers = (params: GetTeamMembersParams) =>
-    requestUserApi<GetTeamMembersOutput>({
-        path: 'teams/GetTeamMembers',
-        login: params.secrets.login,
-        deviceKeys: {
-            accessKey: params.secrets.accessKey,
-            secretKey: params.secrets.secretKey,
+    requestTeamApi<GetTeamMembersOutput>({
+        path: 'teams-teamdevice/GetTeamMembers',
+        teamUuid: params.teamDeviceCredentials.uuid,
+        teamDeviceKeys: {
+            accessKey: params.teamDeviceCredentials.accessKey,
+            secretKey: params.teamDeviceCredentials.secretKey,
         },
         payload: {
-            teamId: params.teamId,
             orderBy: 'login',
             page: params.page,
             limit: params.limit,

--- a/src/endpoints/registerTeamDevice.ts
+++ b/src/endpoints/registerTeamDevice.ts
@@ -1,0 +1,36 @@
+import { Secrets } from '../types';
+import { requestUserApi } from '../requestApi';
+
+export interface RegisterTeamDeviceParams {
+    deviceName: string;
+    secrets: Secrets;
+}
+
+export const registerTeamDevice = (params: RegisterTeamDeviceParams) =>
+    requestUserApi<RegisterTeamDeviceOutput>({
+        path: 'teams/RegisterTeamDevice',
+        login: params.secrets.login,
+        deviceKeys: {
+            accessKey: params.secrets.accessKey,
+            secretKey: params.secrets.secretKey,
+        },
+        payload: {
+            platform: 'command_line',
+            deviceName: params.deviceName,
+        },
+    });
+
+export interface RegisterTeamDeviceOutput {
+    /**
+     * team identifier
+     */
+    teamUuid: string;
+    /**
+     * The registered device access key. Must be stored unencrypted as it is required to log in
+     */
+    deviceAccessKey: string;
+    /**
+     * The registered device secret key. Must be stored securely and never transmited over the network
+     */
+    deviceSecretKey: string;
+}

--- a/src/middleware/getTeamMembers.ts
+++ b/src/middleware/getTeamMembers.ts
@@ -1,25 +1,17 @@
-import { getPremiumStatus, getTeamMembers as getTeamMembersRequest } from '../endpoints';
-import { Secrets } from '../types';
+import { getTeamMembers as getTeamMembersRequest } from '../endpoints';
+import { TeamDeviceCredentials } from '../types';
 
 interface GetTeamMembersParams {
-    secrets: Secrets;
+    teamDeviceCredentials: TeamDeviceCredentials;
     page: number;
     limit: number;
 }
 
 export const getTeamMembers = async (params: GetTeamMembersParams) => {
-    const { secrets, page, limit } = params;
+    const { teamDeviceCredentials, page, limit } = params;
 
-    const premiumStatus = await getPremiumStatus({
-        secrets,
-    });
-    const teamId = premiumStatus.b2bStatus?.currentTeam?.teamId;
-    if (!teamId) {
-        throw new Error('User not part of a team');
-    }
     const response = await getTeamMembersRequest({
-        secrets,
-        teamId,
+        teamDeviceCredentials,
         page,
         limit,
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,12 @@ export interface DeviceKeys {
     serverKeyEncrypted: string | null;
 }
 
+export interface TeamDeviceCredentials {
+    uuid: string;
+    accessKey: string;
+    secretKey: string;
+}
+
 export interface DeviceConfiguration extends DeviceKeys {
     login: string;
     version: string;

--- a/src/utils/gotImplementation.ts
+++ b/src/utils/gotImplementation.ts
@@ -10,5 +10,6 @@ export const gotImplementation: apiconnect.RequestFunction<got.Response<string>>
         headers,
         json,
         retry: { limit: 3 },
+        throwHttpErrors: false,
     });
 };

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,3 +1,5 @@
+import { TeamDeviceCredentials } from '../types';
+
 export const notEmpty = <TValue>(value: TValue | null | undefined): value is TValue => {
     return value !== null && value !== undefined;
 };
@@ -9,4 +11,18 @@ export const parseBooleanString = (booleanString: string): boolean => {
         return false;
     }
     throw new Error("The provided boolean variable should be either 'true' or 'false'");
+};
+
+// TODO move this somewhere else
+export const getTeamDeviceCredentialsFromEnv = (): TeamDeviceCredentials | null => {
+    const { DASHLANE_TEAM_UUID, DASHLANE_TEAM_ACCESS_KEY, DASHLANE_TEAM_SECRET_KEY } = process.env;
+    if (DASHLANE_TEAM_UUID && DASHLANE_TEAM_ACCESS_KEY && DASHLANE_TEAM_SECRET_KEY) {
+        return {
+            uuid: DASHLANE_TEAM_UUID,
+            accessKey: DASHLANE_TEAM_ACCESS_KEY,
+            secretKey: DASHLANE_TEAM_SECRET_KEY,
+        };
+    } else {
+        return null;
+    }
 };


### PR DESCRIPTION
 Add basic support for team credentials

- `team generate-credentials` to generate new team credentials
- `team members` migrated to use team credentials