### PR TITLE
Stop using GetAuditLogs endpoint.

### DIFF
--- a/src/endpoints/getAuditLogs.ts
+++ b/src/endpoints/getAuditLogs.ts
@@ -1,30 +1,107 @@
 import { requestUserApi } from '../requestApi';
 import { Secrets } from '../types';
 
-interface GetTeamMembersParams {
+export interface StartAuditLogsQueryParams {
     secrets: Secrets;
-    page: number;
-    limit: number;
+
+    /**
+     * The start of the date range to query audit logs by. The format is unix timestamp in seconds. Only the date is used, not the time.
+     */
+    startDateRangeUnix: number;
+    /**
+     * The end of the date range of to query audit logs by. The format is unix timestamp in seconds. Only the date is used, not the time.
+     */
+    endDateRangeUnix: number;
+    /**
+     * The user ID of the author of the audit log.
+     */
+    authorUserId?: number;
+    /**
+     * The ID of the user targeted by the audit log action.
+     */
+    targetUserId?: number;
+    /**
+     * The ID of the sharing group targeted by the audit log action.
+     */
+    sharingGroupId?: number;
+    /**
+     * The types of audit logs to filter by.
+     */
+    logType?: string;
+    /**
+     * The categories audit logs to filter by.
+     */
+    category?: string;
+    /**
+     * Additional properties to filter by. Refer to the specific audit log schema for property details.
+     */
+    properties?: {
+        propName: string;
+        value: string;
+    }[];
 }
 
-export const getAuditLogs = (params: GetTeamMembersParams) => {
-    return requestUserApi<GetAuditLogsOutput>({
-        path: 'teams/GetAuditLogs',
-        login: params.secrets.login,
+export interface StartAuditLogsQueryOutput {
+    /**
+     * The query execution ID. Use this value to retrieve the results of the query.
+     */
+    queryExecutionId: string;
+}
+
+export const startAuditLogsQuery = (params: StartAuditLogsQueryParams) => {
+    const { secrets, ...payload } = params;
+    return requestUserApi<StartAuditLogsQueryOutput>({
+        path: 'teams/StartAuditLogsQuery',
+        login: secrets.login,
         deviceKeys: {
-            accessKey: params.secrets.accessKey,
-            secretKey: params.secrets.secretKey,
+            accessKey: secrets.accessKey,
+            secretKey: secrets.secretKey,
         },
-        payload: {
-            pageNumber: params.page,
-            pageCount: params.limit,
-        },
+        payload,
     });
 };
 
-export interface GetAuditLogsOutput {
+export interface GetAuditLogQueryResultsParams {
+    secrets: Secrets;
+
     /**
-     * Array of audit logs
+     * The ID associated with the query executed by the RequestAuditLogs endpoint.
      */
-    auditLogs: string[];
+    queryExecutionId: string;
+    /**
+     * A token that specifies where to continue pagination. To retrieve the next page, pass the nextToken from the response of the previous page call.
+     */
+    nextToken?: string;
+    /**
+     * The maximum number of results to return for this request.
+     */
+    maxResults?: number;
 }
+
+export interface GetAuditLogQueryResultsOutput {
+    /**
+     * The state of the query associated with the provided query execution ID.
+     */
+    state: 'QUEUED' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'CANCELLED';
+    /**
+     * The results of the query.
+     */
+    results: string[];
+    /**
+     * A token to retrieve the next page of results.
+     */
+    nextToken?: string;
+}
+
+export const getAuditLogQueryResults = (params: GetAuditLogQueryResultsParams) => {
+    const { secrets, ...payload } = params;
+    return requestUserApi<GetAuditLogQueryResultsOutput>({
+        path: 'teams/GetAuditLogQueryResults',
+        login: secrets.login,
+        deviceKeys: {
+            accessKey: secrets.accessKey,
+            secretKey: secrets.secretKey,
+        },
+        payload,
+    });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,11 +176,22 @@ teamGroup
     .command('logs')
     .alias('l')
     .description('List audit logs')
-    .argument('[page]', 'Page number', '1')
-    .argument('[limit]', 'Limit of logs per page', '1000')
-    .action(async (page: string, limit: string) => {
+    .option('--start <start>', 'start timestamp', '0')
+    .option('--end <end>', 'end timestamp', 'now')
+    .option('--type <type>', 'log type')
+    .option('--category <category>', 'log category')
+    .action(async (options: { start: string, end: string, type: string, category: string }) => {
+        const { start, type, category } = options;
+        const end = options.end === 'now' ? Math.floor(Date.now() / 1000).toString() : options.end;
+
         const { db, secrets } = await connectAndPrepare({ autoSync: false });
-        await getAuditLogs({ secrets, page: parseInt(page), limit: parseInt(limit) });
+        await getAuditLogs({
+            secrets,
+            startDateRangeUnix: parseInt(start),
+            endDateRangeUnix: parseInt(end),
+            logType: type,
+            category,
+        });
         db.close();
     });
 


### PR DESCRIPTION
It is deprecated and replaced by StartAuditLogsQuery / GetAuditLogsQueryResult