### PR TITLE
feat(devices): add list and remove devices commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
         },
         {
             "name": "Léos Julien"
+        },
+        {
+            "name": "Tristan Parisot"
         }
     ],
     "license": "Apache-2.0",

--- a/src/command-handlers/devices.ts
+++ b/src/command-handlers/devices.ts
@@ -55,9 +55,9 @@ export async function removeAllDevices(devices: string[] | null, options: { all:
     const existingDeviceIds = listDevicesResponse.devices.map((device) => device.deviceId);
 
     if (options.all) {
-        devices = existingDevices;
+        devices = existingDeviceIds;
     } else if (options.others) {
-        devices = existingDevices.filter((d) => d != secrets.accessKey);
+        devices = existingDeviceIds.filter((d) => d != secrets.accessKey);
     } else if (!devices) {
         // if there is no devices provided, well we will have an easy job
         // let's not fail
@@ -72,7 +72,7 @@ export async function removeAllDevices(devices: string[] | null, options: { all:
             return;
         }
     }
-    const notFoundDevices = devices.filter((d) => !existingDevices.includes(d));
+    const notFoundDevices = devices.filter((d) => !existingDeviceIds.includes(d));
     if (notFoundDevices.length > 0) {
         throw new Error(`These devices do not exist: ${notFoundDevices.join('\t')}`);
     }
@@ -81,7 +81,6 @@ export async function removeAllDevices(devices: string[] | null, options: { all:
         deviceIds: devices,
         login: deviceConfiguration.login,
         secrets,
-        pairingGroupIds: [],
     });
 
     if (shouldReset) {

--- a/src/command-handlers/devices.ts
+++ b/src/command-handlers/devices.ts
@@ -1,0 +1,42 @@
+import { connectAndPrepare } from '../database';
+import { deactivateDevices, listDevices } from '../endpoints';
+import { reset } from '../middleware';
+import { askConfirmRemoveAllDevices } from '../utils';
+
+export async function listAllDevices() {
+    const { secrets, deviceConfiguration } = await connectAndPrepare({ autoSync: false });
+    if (!deviceConfiguration) {
+        throw new Error('Require to be connected');
+    }
+    const devices = await listDevices({ secrets, login: deviceConfiguration.login });
+
+    // order by last activity, ascending.
+    devices.devices.sort((a, b) => a.lastActivityDateUnix - b.lastActivityDateUnix);
+
+    // print results
+    for (const device of devices.devices) {
+        console.log([device.deviceId, device.deviceName, device.devicePlatform].join('\t'));
+    }
+}
+
+export async function removeAllDevices() {
+    const confirmation = await askConfirmRemoveAllDevices();
+    if (!confirmation) {
+        return;
+    }
+
+    const { secrets, deviceConfiguration, db } = await connectAndPrepare({ autoSync: false });
+    if (!deviceConfiguration) {
+        throw new Error('Requires to be connected');
+    }
+    const devices = await listDevices({ secrets, login: deviceConfiguration.login });
+    const deviceIdsToDelete = devices.devices.map((d) => d.deviceId);
+    await deactivateDevices({
+        deviceIds: deviceIdsToDelete,
+        login: deviceConfiguration.login,
+        secrets,
+        pairingGroupIds: [],
+    });
+    reset({ db, secrets });
+    db.close();
+}

--- a/src/command-handlers/devices.ts
+++ b/src/command-handlers/devices.ts
@@ -14,7 +14,7 @@ export async function listAllDevices(options: { json: boolean }) {
     }
     const listDevicesResponse = await listDevices({ secrets, login: deviceConfiguration.login });
     const result: OutputDevice[] = listDevicesResponse.devices.map(
-        (c) => <OutputDevice>{ ...c, isCurrentDevice: c.deviceId === secrets.accessKey }
+        (device) => <OutputDevice>{ ...device, isCurrentDevice: device.deviceId === secrets.accessKey }
     );
 
     if (options.json) {
@@ -52,7 +52,7 @@ export async function removeAllDevices(devices: string[] | null, options: { all:
         throw new Error('Requires to be connected');
     }
     const listDevicesResponse = await listDevices({ secrets, login: deviceConfiguration.login });
-    const existingDevices = listDevicesResponse.devices.map((d) => d.deviceId);
+    const existingDeviceIds = listDevicesResponse.devices.map((device) => device.deviceId);
 
     if (options.all) {
         devices = existingDevices;

--- a/src/command-handlers/devices.ts
+++ b/src/command-handlers/devices.ts
@@ -1,42 +1,91 @@
 import { connectAndPrepare } from '../database';
-import { deactivateDevices, listDevices } from '../endpoints';
+import { deactivateDevices, listDevices, ListDevicesOutput } from '../endpoints';
 import { reset } from '../middleware';
-import { askConfirmRemoveAllDevices } from '../utils';
+import { askConfirmReset } from '../utils';
 
-export async function listAllDevices() {
+type OutputDevice = ListDevicesOutput['devices'][number] & {
+    isCurrentDevice: boolean;
+};
+
+export async function listAllDevices(options: { json: boolean }) {
     const { secrets, deviceConfiguration } = await connectAndPrepare({ autoSync: false });
     if (!deviceConfiguration) {
         throw new Error('Require to be connected');
     }
-    const devices = await listDevices({ secrets, login: deviceConfiguration.login });
+    const listDevicesResponse = await listDevices({ secrets, login: deviceConfiguration.login });
+    const result: OutputDevice[] = listDevicesResponse.devices.map(
+        (c) => <OutputDevice>{ ...c, isCurrentDevice: c.deviceId === secrets.accessKey }
+    );
 
-    // order by last activity, ascending.
-    devices.devices.sort((a, b) => a.lastActivityDateUnix - b.lastActivityDateUnix);
+    if (options.json) {
+        console.log(JSON.stringify(result));
+    } else {
+        // order by last activity, ascending.
+        // we sort it only on non-json because it is likely that it will be used
+        // for human consumption
+        result.sort((a, b) => a.lastActivityDateUnix - b.lastActivityDateUnix);
 
-    // print results
-    for (const device of devices.devices) {
-        console.log([device.deviceId, device.deviceName, device.devicePlatform].join('\t'));
+        // print results
+        for (const device of result) {
+            console.log(
+                [
+                    device.deviceId,
+                    device.deviceName,
+                    device.devicePlatform,
+                    device.isCurrentDevice ? 'current' : 'other',
+                ].join('\t')
+            );
+        }
     }
 }
 
-export async function removeAllDevices() {
-    const confirmation = await askConfirmRemoveAllDevices();
-    if (!confirmation) {
-        return;
+export async function removeAllDevices(devices: string[] | null, options: { all: boolean; others: boolean }) {
+    if (devices && devices.length > 0 && (options.all || options.others)) {
+        throw new Error('devices cannot be specified when you use --all or --others');
+    }
+    if (options.all && options.others) {
+        throw new Error('Please use either --all, either --other, but not both');
     }
 
     const { secrets, deviceConfiguration, db } = await connectAndPrepare({ autoSync: false });
     if (!deviceConfiguration) {
         throw new Error('Requires to be connected');
     }
-    const devices = await listDevices({ secrets, login: deviceConfiguration.login });
-    const deviceIdsToDelete = devices.devices.map((d) => d.deviceId);
+    const listDevicesResponse = await listDevices({ secrets, login: deviceConfiguration.login });
+    const existingDevices = listDevicesResponse.devices.map((d) => d.deviceId);
+
+    if (options.all) {
+        devices = existingDevices;
+    } else if (options.others) {
+        devices = existingDevices.filter((d) => d != secrets.accessKey);
+    } else if (!devices) {
+        // if there is no devices provided, well we will have an easy job
+        // let's not fail
+        devices = [];
+    }
+
+    const shouldReset = devices.includes(secrets.accessKey);
+
+    if (shouldReset) {
+        const confirmation = await askConfirmReset();
+        if (!confirmation) {
+            return;
+        }
+    }
+    const notFoundDevices = devices.filter((d) => !existingDevices.includes(d));
+    if (notFoundDevices.length > 0) {
+        throw new Error(`These devices do not exist: ${notFoundDevices.join('\t')}`);
+    }
+
     await deactivateDevices({
-        deviceIds: deviceIdsToDelete,
+        deviceIds: devices,
         login: deviceConfiguration.login,
         secrets,
         pairingGroupIds: [],
     });
-    reset({ db, secrets });
+
+    if (shouldReset) {
+        reset({ db, secrets });
+    }
     db.close();
 }

--- a/src/command-handlers/index.ts
+++ b/src/command-handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './devices';

--- a/src/endpoints/deactivateDevices.ts
+++ b/src/endpoints/deactivateDevices.ts
@@ -1,0 +1,26 @@
+import { requestUserApi } from '../requestApi';
+import { Secrets } from '../types';
+
+interface DeactivateDevicesParams {
+    secrets: Secrets;
+    login: string;
+
+    deviceIds: string[];
+    pairingGroupIds: string[];
+}
+
+export interface DeactivateDevicesOutput {}
+
+export const deactivateDevices = (params: DeactivateDevicesParams) =>
+    requestUserApi<DeactivateDevicesOutput>({
+        path: 'devices/DeactivateDevices',
+        payload: {
+            deviceIds: params.deviceIds,
+            pairingGroupIds: params.pairingGroupIds,
+        },
+        login: params.login,
+        deviceKeys: {
+            accessKey: params.secrets.accessKey,
+            secretKey: params.secrets.secretKey,
+        },
+    });

--- a/src/endpoints/deactivateDevices.ts
+++ b/src/endpoints/deactivateDevices.ts
@@ -5,8 +5,14 @@ interface DeactivateDevicesParams {
     secrets: Secrets;
     login: string;
 
-    deviceIds: string[];
-    pairingGroupIds: string[];
+    /**
+     * List of deviceIds to deactivate
+     */
+    deviceIds?: string[];
+    /**
+     * List of pairingGroupIds to deactivate
+     */
+    pairingGroupIds?: string[];
 }
 
 export interface DeactivateDevicesOutput {}

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -9,3 +9,5 @@ export * from './performTotpVerification';
 export * from './requestDeviceRegistration';
 export * from './getAuditLogs';
 export * from './getTeamReport';
+export * from './listDevices';
+export * from './deactivateDevices';

--- a/src/endpoints/listDevices.ts
+++ b/src/endpoints/listDevices.ts
@@ -6,18 +6,36 @@ interface ListDeviceParams {
     login: string;
 }
 
-export interface Device {
-    deviceId: string;
-    deviceName: string;
-    devicePlatform: string;
-    creationDateUnix: number;
-    lastUpdateDateUnix: number;
-    lastActivityDateUnix: number;
-    temporary: boolean;
-    isBucketOwner: boolean;
-}
 export interface ListDevicesOutput {
-    devices: Device[];
+    pairingGroups: {
+        pairingGroupUUID: string;
+        /**
+         * A computed name for the pairing group null if we don't manage to compute one.
+         */
+        name: string;
+        /**
+         * A computed platform for the pairing group null if we don't manage to compute one.
+         */
+        platform: string;
+        devices: string[];
+        isBucketOwner?: boolean;
+    }[];
+    /**
+     * @minItems 1
+     */
+    devices: {
+        deviceId: string;
+        deviceName: null | string;
+        devicePlatform: null | string;
+        creationDateUnix: number;
+        lastUpdateDateUnix: number;
+        lastActivityDateUnix: number;
+        temporary: boolean;
+        /**
+         * FALSE if the device is in a pairing group with isBucketOwner = true
+         */
+        isBucketOwner?: boolean;
+    }[];
 }
 
 export const listDevices = (params: ListDeviceParams) =>

--- a/src/endpoints/listDevices.ts
+++ b/src/endpoints/listDevices.ts
@@ -1,0 +1,32 @@
+import { requestUserApi } from '../requestApi';
+import { Secrets } from '../types';
+
+interface ListDeviceParams {
+    secrets: Secrets;
+    login: string;
+}
+
+export interface Device {
+    deviceId: string;
+    deviceName: string;
+    devicePlatform: string;
+    creationDateUnix: number;
+    lastUpdateDateUnix: number;
+    lastActivityDateUnix: number;
+    temporary: boolean;
+    isBucketOwner: boolean;
+}
+export interface ListDevicesOutput {
+    devices: Device[];
+}
+
+export const listDevices = (params: ListDeviceParams) =>
+    requestUserApi<ListDevicesOutput>({
+        path: 'devices/ListDevices',
+        payload: {},
+        login: params.login,
+        deviceKeys: {
+            accessKey: params.secrets.accessKey,
+            secretKey: params.secrets.secretKey,
+        },
+    });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
 } from './middleware';
 import { cliVersionToString, CLI_VERSION } from './cliVersion';
 import { registerTeamDevice } from './endpoints/registerTeamDevice';
+import { listAllDevices, removeAllDevices } from './command-handlers';
 
 const teamDeviceCredentials = getTeamDeviceCredentialsFromEnv();
 
@@ -257,6 +258,17 @@ program
             db.close();
         }
     });
+
+const devicesGroup = program.command('devices').alias('d').description('Operations on devices');
+
+devicesGroup
+    .command('list')
+    .description('Lists all registered devices that can access to your account')
+    .action(listAllDevices);
+devicesGroup
+    .command('remove-all')
+    .description('Unregisters all devices that can access your account, including this one. This implies reset')
+    .action(removeAllDevices);
 
 program.parseAsync().catch((error: Error) => {
     console.error(`ERROR: ${error.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,7 +271,7 @@ devicesGroup
     .option('--all', 'remove all devices (dangerous)')
     .option('--other', 'remove all other devices')
     .argument('[device ids...]', 'ids of the devices to remove')
-    .description('Unregisters a list of devices. Unregistering the CLI will implies a reset')
+    .description('Unregisters a list of devices. Unregistering the CLI will implies doing a "dcli reset"')
     .action(removeAllDevices);
 
 program.parseAsync().catch((error: Error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,11 +263,15 @@ const devicesGroup = program.command('devices').alias('d').description('Operatio
 
 devicesGroup
     .command('list')
+    .option('--json', 'Output in JSON format')
     .description('Lists all registered devices that can access to your account')
     .action(listAllDevices);
 devicesGroup
-    .command('remove-all')
-    .description('Unregisters all devices that can access your account, including this one. This implies reset')
+    .command('remove')
+    .option('--all', 'remove all devices (dangerous)')
+    .option('--other', 'remove all other devices')
+    .argument('[device ids...]', 'ids of the devices to remove')
+    .description('Unregisters a list of devices. Unregistering the CLI will implies a reset')
     .action(removeAllDevices);
 
 program.parseAsync().catch((error: Error) => {

--- a/src/utils/dialogs.ts
+++ b/src/utils/dialogs.ts
@@ -71,19 +71,6 @@ export const askConfirmReset = async () => {
     return response.confirmReset === 'Yes';
 };
 
-export const askConfirmRemoveAllDevices = async () => {
-    const response = await inquirer.prompt<{ confirmRemoveAllDevices: string }>([
-        {
-            type: 'list',
-            name: 'confirmRemoveAllDevices',
-            message:
-                'You could be locked out of your account if you forgot your OTP/contact email. Do you really want to remove all registered devices ?',
-            choices: ['Yes', 'No'],
-        },
-    ]);
-    return response.confirmRemoveAllDevices === 'Yes';
-};
-
 export const askCredentialChoice = async (params: { matchedCredentials: VaultCredential[]; hasFilters: boolean }) => {
     const message = params.hasFilters
         ? 'There are multiple results for your query, pick one:'

--- a/src/utils/dialogs.ts
+++ b/src/utils/dialogs.ts
@@ -71,6 +71,19 @@ export const askConfirmReset = async () => {
     return response.confirmReset === 'Yes';
 };
 
+export const askConfirmRemoveAllDevices = async () => {
+    const response = await inquirer.prompt<{ confirmRemoveAllDevices: string }>([
+        {
+            type: 'list',
+            name: 'confirmRemoveAllDevices',
+            message:
+                'You could be locked out of your account if you forgot your OTP/contact email. Do you really want to remove all registered devices ?',
+            choices: ['Yes', 'No'],
+        },
+    ]);
+    return response.confirmRemoveAllDevices === 'Yes';
+};
+
 export const askCredentialChoice = async (params: { matchedCredentials: VaultCredential[]; hasFilters: boolean }) => {
     const message = params.hasFilters
         ? 'There are multiple results for your query, pick one:'


### PR DESCRIPTION
# List and remove devices

## Why ?
I often ends up having thousands of connected devices connected to my tests account.
Sometimes, i need to test device-removal workflows and I do not want to manually scroll and find which device to remove from the back office.

## Also added
- Deleting a single device
- Listing devices in json format
- Deleting "other" devices than the CLI instance.
