### PR TITLE
Revoke team device credentials by access key

### DIFF
--- a/src/endpoints/deactivateTeamDevice.ts
+++ b/src/endpoints/deactivateTeamDevice.ts
@@ -1,0 +1,22 @@
+import { Secrets } from '../types';
+import { requestUserApi } from '../requestApi';
+
+export interface DeactivateTeamDeviceParams {
+    teamDeviceAccessKey: string;
+    secrets: Secrets;
+}
+
+export const deactivateTeamDevice = (params: DeactivateTeamDeviceParams) =>
+    requestUserApi<DeactivateTeamDeviceOutput>({
+        path: 'teams/DeactivateTeamDevice',
+        login: params.secrets.login,
+        deviceKeys: {
+            accessKey: params.secrets.accessKey,
+            secretKey: params.secrets.secretKey,
+        },
+        payload: {
+            teamDeviceAccessKey: params.teamDeviceAccessKey,
+        },
+    });
+
+export interface DeactivateTeamDeviceOutput {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 import { cliVersionToString, CLI_VERSION } from './cliVersion';
 import { registerTeamDevice } from './endpoints/registerTeamDevice';
 import { listAllDevices, removeAllDevices } from './command-handlers';
+import { deactivateTeamDevice } from './endpoints/deactivateTeamDevice';
 
 const teamDeviceCredentials = getTeamDeviceCredentialsFromEnv();
 
@@ -172,6 +173,18 @@ teamGroup
             console.log(`export DASHLANE_TEAM_ACCESS_KEY=${credentials.deviceAccessKey}`);
             console.log(`export DASHLANE_TEAM_SECRET_KEY=${credentials.deviceSecretKey}`);
         }
+    });
+
+teamGroup
+    .command('revoke-credentials')
+    .description('Revoke credentials by access key')
+    .argument('<accessKey>', 'Access key of the credentials to revoke')
+    .action(async (accessKey: string) => {
+        const { db, secrets } = await connectAndPrepare({ autoSync: false });
+        await deactivateTeamDevice({ secrets, teamDeviceAccessKey: accessKey });
+        db.close();
+
+        console.log('The credentials have been revoked');
     });
 
 teamGroup


### PR DESCRIPTION
Add a new command to revoke previously generated team devices by access key.

