### PR TITLE
Migrate audit logs to team device authentication

### DIFF
--- a/src/endpoints/getAuditLogs.ts
+++ b/src/endpoints/getAuditLogs.ts
@@ -1,8 +1,8 @@
-import { requestUserApi } from '../requestApi';
-import { Secrets } from '../types';
+import { requestTeamApi } from '../requestApi';
+import { TeamDeviceCredentials } from '../types';
 
 export interface StartAuditLogsQueryParams {
-    secrets: Secrets;
+    teamDeviceCredentials: TeamDeviceCredentials;
 
     /**
      * The start of the date range to query audit logs by. The format is unix timestamp in seconds. Only the date is used, not the time.
@@ -49,20 +49,20 @@ export interface StartAuditLogsQueryOutput {
 }
 
 export const startAuditLogsQuery = (params: StartAuditLogsQueryParams) => {
-    const { secrets, ...payload } = params;
-    return requestUserApi<StartAuditLogsQueryOutput>({
-        path: 'teams/StartAuditLogsQuery',
-        login: secrets.login,
-        deviceKeys: {
-            accessKey: secrets.accessKey,
-            secretKey: secrets.secretKey,
+    const { teamDeviceCredentials, ...payload } = params;
+    return requestTeamApi<StartAuditLogsQueryOutput>({
+        path: 'auditlogs-teamdevice/StartAuditLogsQuery',
+        teamUuid: teamDeviceCredentials.uuid,
+        teamDeviceKeys: {
+            accessKey: teamDeviceCredentials.accessKey,
+            secretKey: teamDeviceCredentials.secretKey,
         },
         payload,
     });
 };
 
 export interface GetAuditLogQueryResultsParams {
-    secrets: Secrets;
+    teamDeviceCredentials: TeamDeviceCredentials;
 
     /**
      * The ID associated with the query executed by the RequestAuditLogs endpoint.
@@ -94,13 +94,13 @@ export interface GetAuditLogQueryResultsOutput {
 }
 
 export const getAuditLogQueryResults = (params: GetAuditLogQueryResultsParams) => {
-    const { secrets, ...payload } = params;
-    return requestUserApi<GetAuditLogQueryResultsOutput>({
-        path: 'teams/GetAuditLogQueryResults',
-        login: secrets.login,
-        deviceKeys: {
-            accessKey: secrets.accessKey,
-            secretKey: secrets.secretKey,
+    const { teamDeviceCredentials, ...payload } = params;
+    return requestTeamApi<GetAuditLogQueryResultsOutput>({
+        path: 'auditlogs-teamdevice/GetAuditLogQueryResults',
+        teamUuid: teamDeviceCredentials.uuid,
+        teamDeviceKeys: {
+            accessKey: teamDeviceCredentials.accessKey,
+            secretKey: teamDeviceCredentials.secretKey,
         },
         payload,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,19 +139,6 @@ Use generate-credentials to generate some team credentials (requires to be a tea
 }
 
 teamGroup
-    .command('members')
-    .alias('m')
-    .description('List team members')
-    .argument('[page]', 'Page number', '0')
-    .argument('[limit]', 'Limit of members per page', '0')
-    .action(async (page: string, limit: string) => {
-        if (!teamDeviceCredentials) {
-            throw new Error('Could not find team credentials');
-        }
-        await getTeamMembers({ teamDeviceCredentials, page: parseInt(page), limit: parseInt(limit) });
-    });
-
-teamGroup
     .command('generate-credentials')
     .option('--json', 'Output in JSON format')
     .description('Generate new team credentials')
@@ -188,6 +175,19 @@ teamGroup
     });
 
 teamGroup
+    .command('members')
+    .alias('m')
+    .description('List team members')
+    .argument('[page]', 'Page number', '0')
+    .argument('[limit]', 'Limit of members per page', '0')
+    .action(async (page: string, limit: string) => {
+        if (!teamDeviceCredentials) {
+            throw new Error('Could not find team credentials');
+        }
+        await getTeamMembers({ teamDeviceCredentials, page: parseInt(page), limit: parseInt(limit) });
+    });
+
+teamGroup
     .command('logs')
     .alias('l')
     .description('List audit logs')
@@ -196,12 +196,16 @@ teamGroup
     .option('--type <type>', 'log type')
     .option('--category <category>', 'log category')
     .action(async (options: { start: string; end: string; type: string; category: string }) => {
+        if (!teamDeviceCredentials) {
+            throw new Error('Could not find team credentials');
+        }
+
         const { start, type, category } = options;
         const end = options.end === 'now' ? Math.floor(Date.now() / 1000).toString() : options.end;
 
-        const { db, secrets } = await connectAndPrepare({ autoSync: false });
+        const { db } = await connectAndPrepare({ autoSync: false });
         await getAuditLogs({
-            secrets,
+            teamDeviceCredentials,
             startDateRangeUnix: parseInt(start),
             endDateRangeUnix: parseInt(end),
             logType: type,

--- a/src/middleware/getAuditLogs.ts
+++ b/src/middleware/getAuditLogs.ts
@@ -4,16 +4,16 @@ import { getAuditLogQueryResults, startAuditLogsQuery, StartAuditLogsQueryParams
 const MAX_RESULT = 1000;
 
 export const getAuditLogs = async (params: StartAuditLogsQueryParams) => {
-    const { secrets } = params;
+    const { teamDeviceCredentials } = params;
 
     const { queryExecutionId } = await startAuditLogsQuery(params);
 
-    let result = await getAuditLogQueryResults({ secrets, queryExecutionId, maxResults: MAX_RESULT });
+    let result = await getAuditLogQueryResults({ teamDeviceCredentials, queryExecutionId, maxResults: MAX_RESULT });
     winston.debug(`Query state: ${result.state}`);
 
     while (['QUEUED', 'RUNNING'].includes(result.state)) {
         await new Promise((resolve) => setTimeout(resolve, 2000));
-        result = await getAuditLogQueryResults({ secrets, queryExecutionId, maxResults: MAX_RESULT });
+        result = await getAuditLogQueryResults({ teamDeviceCredentials, queryExecutionId, maxResults: MAX_RESULT });
         winston.debug(`Query state: ${result.state}`);
     }
 
@@ -24,7 +24,7 @@ export const getAuditLogs = async (params: StartAuditLogsQueryParams) => {
     let logs = result.results;
     while (result.nextToken) {
         result = await getAuditLogQueryResults({
-            secrets,
+            teamDeviceCredentials,
             queryExecutionId,
             maxResults: MAX_RESULT,
             nextToken: result.nextToken,


### PR DESCRIPTION
This allows to fetch audit logs with the new endpoints and the new authentication mechanism.
It also allows usage into a CI for instance.