### PR TITLE
Use device credentials from env

### DIFF
--- a/documentation/pages/personal/devices.mdx
+++ b/documentation/pages/personal/devices.mdx
@@ -67,6 +67,7 @@ Run the suggested commands on your target device (your server or CI) to set the 
 ```sh
 export DASHLANE_DEVICE_ACCESS_KEY=bdd5[..redacted..]6eb
 export DASHLANE_DEVICE_SECRET_KEY=99f7d9bd547c0[..redacted..]c93fa2118cdf7e3d0
+export DASHLANE_LOGIN=email@domain.com
 export DASHLANE_MASTER_PASSWORD=<insert your master password here>
 ```
 

--- a/documentation/theme.config.jsx
+++ b/documentation/theme.config.jsx
@@ -38,7 +38,7 @@ export default {
                     property="og:description"
                     content={frontMatter.description || 'Learn how to access your Dashlane vault and API endpoints from the command line.'}
                 />
-                <link rel="icon" href="/favicon.png" type="image/png" />
+                <link rel="icon" href="/dashlane-cli/favicon.png" type="image/png" />
             </>
         );
     }

--- a/src/command-handlers/devices.ts
+++ b/src/command-handlers/devices.ts
@@ -127,6 +127,7 @@ export const registerNonInteractiveDevice = async (deviceName: string, options: 
         winston.info('The device credentials have been generated, save and run the following commands to export them:');
         console.log(`export DASHLANE_DEVICE_ACCESS_KEY=${deviceAccessKey}`);
         console.log(`export DASHLANE_DEVICE_SECRET_KEY=${deviceSecretKey}`);
+        console.log(`export DASHLANE_LOGIN=${login}`);
         console.log(`export DASHLANE_MASTER_PASSWORD=<insert your master password here>`);
     }
 

--- a/src/command-handlers/logout.ts
+++ b/src/command-handlers/logout.ts
@@ -34,7 +34,7 @@ export const runLogout = async () => {
             deviceIds: [deviceConfiguration.accessKey],
             login: deviceConfiguration.login,
             secrets,
-        });
+        }).catch((error) => console.error('Unable to deactivate the device', error));
     }
     reset({ db, secrets });
     console.log('The local Dashlane local storage has been reset and you have been logged out');

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import winston from 'winston';
 
 import { cliVersionToString, CLI_VERSION } from './cliVersion';
 import { rootCommands } from './commands';
-import { initTeamDeviceCredentials } from './utils';
+import { initDeviceCredentials, initTeamDeviceCredentials } from './utils';
 
 const debugLevel = process.argv.indexOf('--debug') !== -1 ? 'debug' : 'info';
 
@@ -15,6 +15,7 @@ winston.configure({
 });
 
 initTeamDeviceCredentials();
+initDeviceCredentials();
 
 const program = new Command();
 

--- a/src/modules/crypto/keychainManager.ts
+++ b/src/modules/crypto/keychainManager.ts
@@ -12,6 +12,7 @@ import { perform2FAVerification, registerDevice } from '../auth';
 import { DeviceConfiguration, Secrets } from '../../types';
 import { askEmailAddress, askMasterPassword } from '../../utils/dialogs';
 import { get2FAStatusUnauthenticated } from '../../endpoints/get2FAStatusUnauthenticated';
+import { getDeviceCredentials } from '../../utils';
 
 const SERVICE = 'dashlane-cli';
 
@@ -86,10 +87,17 @@ const getSecretsWithoutDB = async (
     const localKey = generateLocalKey();
 
     // Register the user's device
-    const { deviceAccessKey, deviceSecretKey, serverKey } = await registerDevice({
-        login,
-        deviceName: `${os.hostname()} - ${os.platform()}-${os.arch()}`,
-    });
+    const deviceCredentials = getDeviceCredentials();
+    const { deviceAccessKey, deviceSecretKey, serverKey } = deviceCredentials
+        ? {
+              deviceAccessKey: deviceCredentials.accessKey,
+              deviceSecretKey: deviceCredentials.secretKey,
+              serverKey: undefined,
+          }
+        : await registerDevice({
+              login,
+              deviceName: `${os.hostname()} - ${os.platform()}-${os.arch()}`,
+          });
 
     // Get the authentication type (mainly to identify if the user is with OTP2)
     const { type } = await get2FAStatusUnauthenticated({ login });

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,13 @@ export interface TeamDeviceCredentials {
     secretKey: string;
 }
 
+export interface DeviceCredentials {
+    login: string;
+    accessKey: string;
+    secretKey: string;
+    masterPassword: string;
+}
+
 export interface DeviceConfiguration extends DeviceKeys {
     login: string;
     version: string;

--- a/src/utils/deviceCredentials.ts
+++ b/src/utils/deviceCredentials.ts
@@ -1,0 +1,21 @@
+import { DeviceCredentials } from '../types';
+
+let deviceCredentials: DeviceCredentials | null = null;
+
+export const initDeviceCredentials = (): DeviceCredentials | null => {
+    const { DASHLANE_DEVICE_ACCESS_KEY, DASHLANE_DEVICE_SECRET_KEY, DASHLANE_LOGIN, DASHLANE_MASTER_PASSWORD } =
+        process.env;
+    if (DASHLANE_DEVICE_ACCESS_KEY && DASHLANE_DEVICE_SECRET_KEY && DASHLANE_LOGIN && DASHLANE_MASTER_PASSWORD) {
+        deviceCredentials = {
+            login: DASHLANE_LOGIN,
+            accessKey: DASHLANE_DEVICE_ACCESS_KEY,
+            secretKey: DASHLANE_DEVICE_SECRET_KEY,
+            masterPassword: DASHLANE_MASTER_PASSWORD,
+        };
+    }
+    return deviceCredentials;
+};
+
+export const getDeviceCredentials = (): DeviceCredentials | null => {
+    return deviceCredentials;
+};

--- a/src/utils/dialogs.ts
+++ b/src/utils/dialogs.ts
@@ -1,6 +1,7 @@
 import inquirer from 'inquirer';
 import inquirerSearchList from 'inquirer-search-list';
 import { removeUnderscoresAndCapitalize } from './strings';
+import { getDeviceCredentials } from './deviceCredentials';
 import {
     PrintableVaultCredential,
     PrintableVaultNote,
@@ -14,6 +15,11 @@ export const prompt = inquirer.createPromptModule({ output: process.stderr });
 prompt.registerPrompt('search-list', inquirerSearchList as PromptConstructor);
 
 export const askMasterPassword = async (): Promise<string> => {
+    const deviceCredentials = getDeviceCredentials();
+    if (deviceCredentials !== null) {
+        return deviceCredentials.masterPassword;
+    }
+
     const response = await prompt<{ masterPassword: string }>([
         {
             type: 'password',
@@ -53,6 +59,11 @@ export const askIgnoreBreakingChanges = async () => {
 };
 
 export const askEmailAddress = async (): Promise<string> => {
+    const deviceCredentials = getDeviceCredentials();
+    if (deviceCredentials !== null) {
+        return deviceCredentials.login;
+    }
+
     const response = await prompt<{ login: string }>([
         {
             type: 'input',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './deviceCredentials';
 export * from './dialogs';
 export * from './gotImplementation';
 export * from './strings';


### PR DESCRIPTION
This is a simple way to bypass manually inputing email and master password as well as registering a device.

Fix #130