### PR TITLE
Add JSON field transformation

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
         "got": "^11.8.6",
         "inquirer": "^8.2.5",
         "inquirer-search-list": "^1.2.6",
+        "jsonpath-plus": "^7.2.0",
         "otplib": "^12.0.1",
         "winston": "^3.10.0",
         "xml-js": "^1.6.11",

--- a/src/utils/secretTransformation.ts
+++ b/src/utils/secretTransformation.ts
@@ -1,5 +1,18 @@
+import { JSONPath } from 'jsonpath-plus';
 import { authenticator } from 'otplib';
 
 export const transformOtp = (secret: string) => {
     return authenticator.generate(secret);
+};
+
+export const transformJsonPath = (json: string, path: string) => {
+    const result = JSONPath<unknown>({ path, json: JSON.parse(json) as object, wrap: false });
+    if (result === undefined) {
+        throw new Error(`No matching json path found for "${path}"`);
+    }
+
+    if (typeof result === 'string') {
+        return result;
+    }
+    return JSON.stringify(result);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,7 @@ __metadata:
     husky: ^8.0.3
     inquirer: ^8.2.5
     inquirer-search-list: ^1.2.6
+    jsonpath-plus: ^7.2.0
     mocha: ^10.2.0
     otplib: ^12.0.1
     pkg: ^5.8.1
@@ -3429,6 +3430,13 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 7af3b8e1ac8fe7f1eccc6263c6ca14e1966fcbc74b618d3c78a0a2075579487547b94f72b7a1114e844a1e15bb00d440e5d1720bfc4612d790a6f285d5ea8354
+  languageName: node
+  linkType: hard
+
+"jsonpath-plus@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "jsonpath-plus@npm:7.2.0"
+  checksum: 05f447339d29be861e307d6e812aec1b9b88a3ba6bba286966a4e8bed3e752bee3d715eabfc21dce968be85ccb48bf79d2c1af78da7b9b74cd1b446d4d5d02f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR allows to use JSONPath transformation on fields.

Given this JSON file:

You can do such operations:
```json
{
"store": {
  "book": [
    {
      "category": "reference",
      "author": "Nigel Rees",
      "title": "Sayings of the Century",
      "price": 8.95
    },
    {
      "category": "fiction",
      "author": "Evelyn Waugh",
      "title": "Sword of Honour",
      "price": 12.99
    },
    {
      "category": "fiction",
      "author": "Herman Melville",
      "title": "Moby Dick",
      "isbn": "0-553-21311-3",
      "price": 8.99
    },
    {
      "category": "fiction",
      "author": "J. R. R. Tolkien",
      "title": "The Lord of the Rings",
      "isbn": "0-395-19395-8",
      "price": 22.99
    }
  ],
  "bicycle": {
    "color": "red",
    "price": 19.95
  }
}
}
```

```sh
dcli read 'dl://books.json/content?json=$..*[?(@property === "price" && @ !== 8.95)]'
[19.95,12.99,8.99,22.99]
```

JSONPath system (quite similar to jq) is explained here: https://github.com/JSONPath-Plus/JSONPath#syntax-through-examples