### PR TITLE
Add safeguards milliseconds timestamps

### DIFF
--- a/src/command-handlers/teamLogs.ts
+++ b/src/command-handlers/teamLogs.ts
@@ -4,8 +4,8 @@ import { getTeamDeviceCredentials, jsonToCsv, epochTimestampToIso } from '../uti
 import { GenericLog } from '../types/logs';
 
 export const runTeamLogs = async (options: {
-    start: string;
-    end: string;
+    start: number;
+    end: number;
     type: string;
     category: string;
     csv: boolean;
@@ -13,13 +13,12 @@ export const runTeamLogs = async (options: {
 }) => {
     const teamDeviceCredentials = getTeamDeviceCredentials();
 
-    const { start, type, category } = options;
-    const end = options.end === 'now' ? Date.now().toString() : options.end;
+    const { start, end, type, category } = options;
 
     let logs = await getAuditLogs({
         teamDeviceCredentials,
-        startDateRangeUnix: parseInt(start),
-        endDateRangeUnix: parseInt(end),
+        startDateRangeUnix: start,
+        endDateRangeUnix: end,
         logType: type,
         category,
     });

--- a/src/commands/team/index.ts
+++ b/src/commands/team/index.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { teamCredentialsCommands } from './credentials';
 import { CouldNotFindTeamCredentialsError } from '../../errors';
 import { runTeamLogs, runTeamMembers, runTeamReport } from '../../command-handlers';
-import { customParseInt, getTeamDeviceCredentials } from '../../utils';
+import { customParseInt, customParseTimestampMilliseconds, getTeamDeviceCredentials } from '../../utils';
 
 export const teamCommands = (params: { program: Command }) => {
     const { program } = params;
@@ -37,8 +37,13 @@ export const teamCommands = (params: { program: Command }) => {
         .command('logs')
         .alias('l')
         .description('List audit logs')
-        .option('--start <start>', 'start timestamp in ms', '0')
-        .option('--end <end>', 'end timestamp in ms (use "now" to get the current timestamp)', 'now')
+        .option('--start <start>', 'Start timestamp in ms', customParseTimestampMilliseconds, '0')
+        .option(
+            '--end <end>',
+            'End timestamp in ms (use "now" to get the current timestamp)',
+            customParseTimestampMilliseconds,
+            'now'
+        )
         .option('--type <type>', 'log type')
         .option('--category <category>', 'log category')
         .option('--csv', 'Output in CSV format')

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -24,6 +24,26 @@ export const customParseInt = (value: string, _dummyPrevious: unknown) => {
     return parsedValue;
 };
 
+export const customParseTimestampMilliseconds = (value: string, _dummyPrevious: unknown) => {
+    if (value === 'now') {
+        return Date.now();
+    }
+    if (value === '0') {
+        return 0;
+    }
+
+    // parseInt takes a string and a radix
+    const parsedValue = parseInt(value, 10);
+    if (isNaN(parsedValue)) {
+        throw new commander.InvalidArgumentError('Not a number.');
+    }
+
+    if (parsedValue < 999999999999 || parsedValue > 100000000000000) {
+        throw new commander.InvalidArgumentError('Timestamp must be in milliseconds.');
+    }
+    return parsedValue;
+};
+
 /** Remove underscores and capitalize string */
 export const removeUnderscoresAndCapitalize = (string: string): string => {
     return string


### PR DESCRIPTION
Avoid mistakenly send seconds timestamps to the audit logs command.