### PR TITLE
Fix audit logs now date

### DIFF
--- a/src/commands/team/index.ts
+++ b/src/commands/team/index.ts
@@ -42,7 +42,7 @@ export const teamCommands = (params: { program: Command }) => {
             '--end <end>',
             'End timestamp in ms (use "now" to get the current timestamp)',
             customParseTimestampMilliseconds,
-            'now'
+            Date.now()
         )
         .option('--type <type>', 'log type')
         .option('--category <category>', 'log category')


### PR DESCRIPTION
Bug when using the default parameters for the audit logs