### PR TITLE
Fix: url encode login at device registration

### DIFF
--- a/src/modules/auth/registerDevice.ts
+++ b/src/modules/auth/registerDevice.ts
@@ -52,8 +52,9 @@ export const registerDevice = async (params: RegisterDevice) => {
             otp,
         }));
     } else if (selectedVerificationMethod.type === 'email_token') {
+        const urlEncodedLogin = encodeURIComponent(login);
         winston.info(
-            `Please open the following URL in your browser: https://www.dashlane.com/cli-device-registration?login=${login}`
+            `Please open the following URL in your browser: https://www.dashlane.com/cli-device-registration?login=${urlEncodedLogin}`
         );
         const token = await askToken();
         ({ authTicket } = await performEmailTokenVerification({


### PR DESCRIPTION
A user reported a failed authentication when using `+` signs in their login emails. 
We're now generating properly encoded login urls.

Thanks JB for the report.