### PR TITLE
Support Master Password authentication via env variable

### DIFF
--- a/src/modules/crypto/keychainManager.ts
+++ b/src/modules/crypto/keychainManager.ts
@@ -107,12 +107,15 @@ const getLocalConfigurationWithoutDB = async (
     const { type } = await get2FAStatusUnauthenticated({ login });
 
     let masterPassword = '';
+    let masterPasswordEnv = process.env.DASHLANE_MASTER_PASSWORD;
     let serverKeyEncrypted = null;
     const isSSO = type === 'sso';
 
     // In case of SSO
     if (isSSO) {
         masterPassword = decryptSsoRemoteKey({ ssoServerKey, ssoSpKey, remoteKeys });
+    } else if(masterPasswordEnv) {
+        masterPassword = masterPasswordEnv
     } else {
         masterPassword = await askMasterPassword();
 


### PR DESCRIPTION
When spawning `dcli` in Node it's impossible to get past master password prompt as stdin doesn't works, this fixes it by checking if `DASHLANE_MASTER_PASSWORD` is set when spawning the process.

