### PR TITLE
fix: Support Master Password authentication via env variable

### DIFF
--- a/src/modules/crypto/keychainManager.ts
+++ b/src/modules/crypto/keychainManager.ts
@@ -183,8 +183,8 @@ const getLocalConfigurationWithoutKeychain = async (
         serverKey = await perform2FAVerification({ login, deviceAccessKey: deviceConfiguration.accessKey });
         masterPassword = serverKey ?? '';
     }
-
-    masterPassword += await askMasterPassword();
+    const masterPasswordEnv = process.env.DASHLANE_MASTER_PASSWORD;
+    masterPassword += masterPasswordEnv ?? (await askMasterPassword());
 
     const derivate = await getDerivateUsingParametersFromEncryptedData(
         masterPassword,


### PR DESCRIPTION
The original [PR](https://github.com/Dashlane/dashlane-cli/pull/223) for this wasn't tested and did not work this PR fixes it, I've tested the changes this time.