### PR TITLE
Implement lock mechanism

### DIFF
--- a/src/command-handlers/index.ts
+++ b/src/command-handlers/index.ts
@@ -3,6 +3,7 @@ export * from './configure';
 export * from './devices';
 export * from './exec';
 export * from './inject';
+export * from './lock';
 export * from './logout';
 export * from './passwords';
 export * from './read';

--- a/src/command-handlers/lock.ts
+++ b/src/command-handlers/lock.ts
@@ -1,0 +1,29 @@
+import * as winston from 'winston';
+import { deleteLocalKey } from '../modules/crypto/keychainManager';
+import { connectAndPrepare } from '../modules/database';
+
+export const runLock = async () => {
+    const { db, localConfiguration } = await connectAndPrepare({
+        autoSync: false,
+        shouldNotSaveMasterPasswordIfNoDeviceKeys: true,
+    });
+
+    // Forget the local key stored in the OS keychain because the master password and the DB are enough to retrieve the
+    // local key
+    try {
+        deleteLocalKey(localConfiguration.login);
+    } catch (error) {
+        // Errors are ignored because the OS keychain may be unreachable
+        let errorMessage = 'unknown error';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+        winston.warn(`Unable to lock the vault: ${errorMessage}`);
+    }
+
+    db.prepare('UPDATE device SET masterPasswordEncrypted = ? WHERE login = ?')
+        .bind(null, localConfiguration.login)
+        .run();
+
+    db.close();
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,6 +7,7 @@ import {
     runSync,
     runPassword,
     runSecureNote,
+    runLock,
     runLogout,
     runRead,
     runInject,
@@ -111,6 +112,11 @@ export const rootCommands = (params: { program: Command }) => {
         .option('--filename <filename>', 'Filename of the backup ("dashlane-backup-<unix_timestamp>.db by default")')
         .description('Backup your local vault (will use the current directory by default)')
         .action(runBackup);
+
+    program
+        .command('lock')
+        .description('Lock the vault, next commands will request the master password to unlock it)')
+        .action(runLock);
 
     program
         .command('logout')


### PR DESCRIPTION
When using the keychains, it's possible to run commands indefinitely unless you lock your keychain. 
I'm adding a sub-mechanism to drop the key in keychain so it forces to re-ask for the master password on the next command.

For the ones more concerned about using the keychain:
- you have a configuration available to not store your master password in the keychain
- you can create a cron job or a script that locks your vault at a given period of time or by an action