### PR TITLE
Fix reading of secrets by title

### DIFF
--- a/src/modules/database/vaultContent.ts
+++ b/src/modules/database/vaultContent.ts
@@ -65,6 +65,7 @@ export const findVaultContent = (vaultContent: VaultContent, parsedPath: ParsedP
             (credential) => credential.title === parsedPath.title
         );
         vaultContent.notes = vaultContent.notes.filter((note) => note.title === parsedPath.title);
+        vaultContent.secrets = vaultContent.secrets.filter((secret) => secret.title === parsedPath.title);
     }
 
     if (parsedPath.itemId) {


### PR DESCRIPTION
I started using this cli today but found that it returns the wrong secret when looking up by title.

`dcli read dl://my-secret`

To reproduce the issue, add 2 or more secrets to your vault and lookup each by title. It will always return the same secret
