### PR TITLE
docs: fixes the biometrics option in docs

### DIFF
--- a/documentation/pages/personal/authentication.mdx
+++ b/documentation/pages/personal/authentication.mdx
@@ -64,7 +64,7 @@ dcli configure save-master-password false
 You can unlock the CLI with your biometrics (Touch ID, Face ID) if your machine supports it (only macOS for now).
 
 ```sh copy
-dcli configure user-presence --method biometric
+dcli configure user-presence --method biometrics
 ```
 
 And to disable it:

--- a/documentation/pages/security.mdx
+++ b/documentation/pages/security.mdx
@@ -34,5 +34,5 @@ refer to the [security whitepaper](https://www.dashlane.com/download/whitepaper-
 
 -   You can disable the use of the OS keychain by using the command `dcli configure save-master-password false`. In this case,
     you will be asked for the master password every time you start the application.
--   You can enable biometrics unlock by using the command `dcli configure user-presence --method biometric`. In this case, you will be
+-   You can enable biometrics unlock by using the command `dcli configure user-presence --method biometrics`. In this case, you will be
     asked for a user presence check (e.g. fingerprint) every time you start the application before the OS password management system is requested.


### PR DESCRIPTION
The current option indicated in the doc is

```
dcli configure user-presence --method biometric
```

whereas it should be:

```
dcli configure user-presence --method biometrics
```

I received the error when I just copied the command over. Here is the [src](https://github.com/Dashlane/dashlane-cli/blob/c377153edeacd7a328204fd73cad8a825f228cc3/src/commands/configure.ts#L28-L32).