### PR TITLE
(Feature) Allow user-device and team-device auth for calls through secure tunnel

### DIFF
--- a/src/modules/auth/confidential-sso/index.ts
+++ b/src/modules/auth/confidential-sso/index.ts
@@ -20,6 +20,7 @@ export const doConfidentialSSOVerification = async ({ requestedLogin }: Confiden
         ...api,
         path: 'authentication/RequestLogin2',
         payload: { login: requestedLogin },
+        authentication: { type: 'app' },
     });
 
     const { idpAuthorizeUrl, spCallbackUrl, teamUuid, domainName } = requestLoginResponse;
@@ -56,6 +57,7 @@ export const doConfidentialSSOVerification = async ({ requestedLogin }: Confiden
         ...api,
         path: 'authentication/ConfirmLogin2',
         payload: { teamUuid, domainName, samlResponse },
+        authentication: { type: 'app' },
     });
 
     const ssoVerificationResult = await performSSOVerification({

--- a/src/modules/tunnel-api-connect/steps/types.ts
+++ b/src/modules/tunnel-api-connect/steps/types.ts
@@ -25,11 +25,33 @@ export interface TerminateHelloRequest {
     tunnelUuid: string;
 }
 
+interface AppAuthenticationParams {
+    type: 'app';
+}
+
+interface UserDeviceAuthenticationParams {
+    type: 'userDevice';
+    login: string;
+    deviceKeys: { accessKey: string; secretKey: string };
+}
+
+interface TeamDeviceAuthenticationParams {
+    type: 'teamDevice';
+    teamUuid: string;
+    teamDeviceKeys: { accessKey: string; secretKey: string };
+}
+
+export type AuthenticationParams =
+    | AppAuthenticationParams
+    | UserDeviceAuthenticationParams
+    | TeamDeviceAuthenticationParams;
+
 export interface SendSecureContentParams<R extends ApiRequestsDefault> {
     path: R['path'];
     clientStateIn: sodium.StateAddress;
     clientStateOut: sodium.StateAddress;
     payload: R['input'];
+    authentication?: AuthenticationParams;
 }
 
 export interface TerminateHelloParams {

--- a/src/modules/tunnel-api-connect/types.ts
+++ b/src/modules/tunnel-api-connect/types.ts
@@ -48,7 +48,7 @@ export interface ApiConnect {
     makeOrRefreshSession: (params: RefreshSessionParams) => Promise<void>;
     /** Reinitialize the tunnel when the session has expired (cookie) */
     sendSecureContent: <R extends ApiRequestsDefault>(
-        params: Pick<SendSecureContentParams<R>, 'path' | 'payload'>
+        params: Pick<SendSecureContentParams<R>, 'path' | 'payload' | 'authentication'>
     ) => Promise<R['output']>;
 }
 

--- a/src/requestApi.ts
+++ b/src/requestApi.ts
@@ -101,6 +101,7 @@ export interface RequestUserApi {
         accessKey: string;
         secretKey: string;
     };
+    isNitroEncryptionService?: boolean;
 }
 
 export const requestUserApi = async <T>(params: RequestUserApi): Promise<T> => {
@@ -124,6 +125,7 @@ export interface RequestTeamApi {
         accessKey: string;
         secretKey: string;
     };
+    isNitroEncryptionService?: boolean;
 }
 
 export const requestTeamApi = async <T>(params: RequestTeamApi): Promise<T> => {


### PR DESCRIPTION
Adds a way to call API endpoints with a secure tunnel that have an authentication method different from `app`