### PR TITLE
feat: account recovery

### DIFF
--- a/src/command-handlers/logout.ts
+++ b/src/command-handlers/logout.ts
@@ -1,46 +1,11 @@
-import { Database } from 'better-sqlite3';
-import { deactivateDevices } from '../endpoints/index.js';
-import { connectAndPrepare, connect, reset } from '../modules/database/index.js';
-import { LocalConfiguration, DeviceConfiguration } from '../types.js';
 import { askConfirmReset } from '../utils/index.js';
-import { logger } from '../logger.js';
+import { logout } from '../modules/auth/logout.js';
 
 export const runLogout = async (options: { ignoreRevocation: boolean }) => {
-    if (options.ignoreRevocation) {
-        logger.info("The device credentials won't be revoked on Dashlane's servers.");
-    }
-
     const resetConfirmation = await askConfirmReset();
     if (!resetConfirmation) {
         return;
     }
 
-    let db: Database;
-    let localConfiguration: LocalConfiguration | undefined;
-    let deviceConfiguration: DeviceConfiguration | null | undefined;
-    try {
-        ({ db, localConfiguration, deviceConfiguration } = await connectAndPrepare({
-            autoSync: false,
-            failIfNoDB: true,
-        }));
-    } catch (error) {
-        let errorMessage = 'unknown error';
-        if (error instanceof Error) {
-            errorMessage = error.message;
-        }
-        logger.debug(`Unable to read device configuration during logout: ${errorMessage}`);
-
-        db = connect();
-        db.serialize();
-    }
-    if (localConfiguration && deviceConfiguration && !options.ignoreRevocation) {
-        await deactivateDevices({
-            deviceIds: [deviceConfiguration.accessKey],
-            login: deviceConfiguration.login,
-            localConfiguration,
-        }).catch((error) => logger.error('Unable to deactivate the device', error));
-    }
-    reset({ db, localConfiguration });
-    logger.success('The local Dashlane local storage has been reset and you have been logged out.');
-    db.close();
+    await logout({ ignoreRevocation: options.ignoreRevocation });
 };

--- a/src/command-handlers/recovery.ts
+++ b/src/command-handlers/recovery.ts
@@ -1,0 +1,37 @@
+import { logger } from '../logger';
+import { logout } from '../modules/auth';
+import { connectAndPrepare } from '../modules/database/connectAndPrepare';
+import { askConfirmRecovery, askConfirmShowMp } from '../utils';
+import { sync } from './sync';
+
+export const runAccountRecovery = async () => {
+    const doRecovery = await askConfirmRecovery();
+    if (!doRecovery) {
+        return;
+    }
+    const shouldShowMp = await askConfirmShowMp();
+
+    await logout({ ignoreRevocation: false });
+    const { db, localConfiguration, deviceConfiguration } = await connectAndPrepare({
+        autoSync: false,
+        recoveryOptions: {
+            promptForArk: true,
+            displayMasterpassword: shouldShowMp,
+        },
+    });
+
+    try {
+        await sync({ db, localConfiguration, deviceConfiguration });
+        logger.success('Account recovered! you can use the CLI to export its data.');
+    } catch (error) {
+        logger.error(
+            'Sync failed. It probably means that the masterpassword locked behind the recovery key\n' +
+                'is not matching. Try running the command again and show the masterpassword. Maybe you will\n' +
+                'remember the one you initially set up'
+        );
+
+        throw error;
+    } finally {
+        db.close();
+    }
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,6 +15,7 @@ import {
     runBackup,
     runSecret,
 } from '../command-handlers/index.js';
+import { runAccountRecovery } from '../command-handlers/recovery.js';
 
 export const rootCommands = (params: { program: Command }) => {
     const { program } = params;
@@ -112,6 +113,11 @@ export const rootCommands = (params: { program: Command }) => {
         .option('--filename <filename>', 'Filename of the backup ("dashlane-backup-<unix_timestamp>.db by default")')
         .description('Backup your local vault (will use the current directory by default)')
         .action(runBackup);
+
+    program
+        .command('recover-account')
+        .description('interactively login to an account with a recovery key')
+        .action(runAccountRecovery);
 
     program
         .command('lock')

--- a/src/endpoints/getEncryptedVaultKey.ts
+++ b/src/endpoints/getEncryptedVaultKey.ts
@@ -1,0 +1,19 @@
+import { requestAppApi } from '../requestApi.js';
+
+interface GetEncryptedVaultKeyParams {
+    login: string;
+    authTicket: string;
+}
+
+export interface GetEncryptedVaultKeyResult {
+    encryptedVaultKey: string;
+}
+
+export const getEncryptedVaultKey = ({ authTicket, login }: GetEncryptedVaultKeyParams) =>
+    requestAppApi<GetEncryptedVaultKeyResult>({
+        path: 'accountrecovery/GetEncryptedVaultKey',
+        payload: {
+            authTicket,
+            login,
+        },
+    });

--- a/src/modules/auth/getAuthenticationTickets.ts
+++ b/src/modules/auth/getAuthenticationTickets.ts
@@ -1,0 +1,74 @@
+import {
+    performDashlaneAuthenticatorVerification,
+    performDuoPushVerification,
+    performEmailTokenVerification,
+    performTotpVerification,
+} from '../../endpoints';
+import { getAuthenticationMethodsForDevice } from '../../endpoints/getAuthenticationMethodsForDevice';
+import { logger } from '../../logger';
+import { askOtp, askToken, askVerificationMethod } from '../../utils/dialogs';
+import { doConfidentialSSOVerification } from './confidential-sso';
+import { doSSOVerification } from './sso';
+
+export const getAuthenticationTickets = async (login: string) => {
+    logger.debug('Registering the device...');
+
+    // Log in via a compatible verification method
+    const { verifications, accountType } = await getAuthenticationMethodsForDevice({ login });
+
+    if (accountType === 'invisibleMasterPassword') {
+        throw new Error('Master password-less is currently not supported');
+    }
+
+    const nonEmptyVerifications = verifications.filter((method) => method.type);
+
+    const selectedVerificationMethod =
+        nonEmptyVerifications.length > 1
+            ? await askVerificationMethod(nonEmptyVerifications)
+            : nonEmptyVerifications[0];
+
+    let authTicket: string;
+    let ssoSpKey: string | null = null;
+    if (!selectedVerificationMethod || Object.keys(selectedVerificationMethod).length === 0) {
+        throw new Error('No verification method selected');
+    }
+
+    if (selectedVerificationMethod.type === 'duo_push') {
+        logger.info('Please accept the Duo push notification on your phone.');
+        ({ authTicket } = await performDuoPushVerification({ login }));
+    } else if (selectedVerificationMethod.type === 'dashlane_authenticator') {
+        logger.info('Please accept the Dashlane Authenticator push notification on your phone.');
+        ({ authTicket } = await performDashlaneAuthenticatorVerification({ login }));
+    } else if (selectedVerificationMethod.type === 'totp') {
+        const otp = await askOtp();
+        ({ authTicket } = await performTotpVerification({
+            login,
+            otp,
+        }));
+    } else if (selectedVerificationMethod.type === 'email_token') {
+        const urlEncodedLogin = encodeURIComponent(login);
+        logger.info(
+            `Please open the following URL in your browser: https://www.dashlane.com/cli-device-registration?login=${urlEncodedLogin}`
+        );
+        const token = await askToken();
+        ({ authTicket } = await performEmailTokenVerification({
+            login,
+            token,
+        }));
+    } else if (selectedVerificationMethod.type === 'sso') {
+        if (selectedVerificationMethod.ssoInfo.isNitroProvider) {
+            ({ authTicket, ssoSpKey } = await doConfidentialSSOVerification({
+                requestedLogin: login,
+            }));
+        } else {
+            ({ authTicket, ssoSpKey } = await doSSOVerification({
+                requestedLogin: login,
+                serviceProviderURL: selectedVerificationMethod.ssoInfo.serviceProviderUrl,
+            }));
+        }
+    } else {
+        throw new Error('Auth verification method not supported: ' + selectedVerificationMethod.type);
+    }
+
+    return { ssoSpKey, authTicket };
+};

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,3 +1,6 @@
 export * from './perform2FAVerification.js';
 export * from './registerDevice.js';
 export * from './userPresenceVerification.js';
+export * from './getAuthenticationTickets.js';
+export * from './recovery/getMasterpasswordFromArkPrompt.js';
+export * from './logout.js';

--- a/src/modules/auth/logout.ts
+++ b/src/modules/auth/logout.ts
@@ -1,0 +1,40 @@
+import { Database } from 'better-sqlite3';
+import { deactivateDevices } from '../../endpoints';
+import { logger } from '../../logger';
+import { LocalConfiguration, DeviceConfiguration } from '../../types';
+import { connectAndPrepare, connect, reset } from '../database';
+
+export const logout = async (options: { ignoreRevocation: boolean }) => {
+    if (options.ignoreRevocation) {
+        logger.info("The device credentials won't be revoked on Dashlane's servers.");
+    }
+
+    let db: Database;
+    let localConfiguration: LocalConfiguration | undefined;
+    let deviceConfiguration: DeviceConfiguration | null | undefined;
+    try {
+        ({ db, localConfiguration, deviceConfiguration } = await connectAndPrepare({
+            autoSync: false,
+            failIfNoDB: true,
+        }));
+    } catch (error) {
+        let errorMessage = 'unknown error';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+        logger.debug(`Unable to read device configuration during logout: ${errorMessage}`);
+
+        db = connect();
+        db.serialize();
+    }
+    if (localConfiguration && deviceConfiguration && !options.ignoreRevocation) {
+        await deactivateDevices({
+            deviceIds: [deviceConfiguration.accessKey],
+            login: deviceConfiguration.login,
+            localConfiguration,
+        }).catch((error) => logger.error('Unable to deactivate the device', error));
+    }
+    reset({ db, localConfiguration });
+    logger.success('The local Dashlane local storage has been reset and you have been logged out.');
+    db.close();
+};

--- a/src/modules/auth/recovery/getMasterpasswordFromArkPrompt.ts
+++ b/src/modules/auth/recovery/getMasterpasswordFromArkPrompt.ts
@@ -1,0 +1,34 @@
+import { getEncryptedVaultKey } from '../../../endpoints/getEncryptedVaultKey';
+import { logger } from '../../../logger';
+import { askAccountRecoveryKey } from '../../../utils/dialogs';
+import { decryptAesCbcHmac256, getDerivateUsingParametersFromEncryptedData } from '../../crypto/decrypt';
+import { deserializeEncryptedData } from '../../crypto/encryptedDataDeserialization';
+
+function cleanArk(input: string): string {
+    return input.toUpperCase().replaceAll(/[^A-Z0-9]/g, '');
+}
+export async function getMasterpasswordFromArkPrompt(authTicket: string, login: string): Promise<string> {
+    const { encryptedVaultKey: encryptedVaultKeyBase64 } = await getEncryptedVaultKey({
+        authTicket,
+        login,
+    });
+
+    const ark = cleanArk(await askAccountRecoveryKey());
+
+    const buffer = Buffer.from(encryptedVaultKeyBase64, 'base64');
+    const decodedBase64 = buffer.toString('ascii');
+    const { encryptedData } = deserializeEncryptedData(decodedBase64, buffer);
+    const derivatedKey = await getDerivateUsingParametersFromEncryptedData(ark, encryptedData);
+
+    try {
+        const decryptedVaultKey = decryptAesCbcHmac256({
+            cipherData: encryptedData.cipherData,
+            originalKey: derivatedKey,
+            inflatedKey: encryptedData.cipherConfig.cipherMode === 'cbchmac64',
+        });
+        return decryptedVaultKey.toString('utf-8');
+    } catch (e) {
+        logger.error('Failed to decrypt MP. Maybe the ARK entered is incorrect');
+        throw e;
+    }
+}

--- a/src/modules/auth/registerDevice.ts
+++ b/src/modules/auth/registerDevice.ts
@@ -1,84 +1,15 @@
-import { doSSOVerification } from './sso/index.js';
-import { doConfidentialSSOVerification } from './confidential-sso/index.js';
-import {
-    completeDeviceRegistration,
-    performDashlaneAuthenticatorVerification,
-    performDuoPushVerification,
-    performEmailTokenVerification,
-    performTotpVerification,
-} from '../../endpoints/index.js';
-import { askOtp, askToken, askVerificationMethod } from '../../utils/index.js';
-import { getAuthenticationMethodsForDevice } from '../../endpoints/getAuthenticationMethodsForDevice.js';
-import { logger } from '../../logger.js';
+import { completeDeviceRegistration } from '../../endpoints/index.js';
+import { getAuthenticationTickets } from './getAuthenticationTickets.js';
 
 interface RegisterDevice {
     login: string;
     deviceName: string;
 }
 
-export const registerDevice = async (params: RegisterDevice) => {
-    const { login, deviceName } = params;
-    logger.debug('Registering the device...');
-
-    // Log in via a compatible verification method
-    const { verifications, accountType } = await getAuthenticationMethodsForDevice({ login });
-
-    if (accountType === 'invisibleMasterPassword') {
-        throw new Error('Master password-less is currently not supported');
-    }
-
-    const nonEmptyVerifications = verifications.filter((method) => method.type);
-
-    const selectedVerificationMethod =
-        nonEmptyVerifications.length > 1
-            ? await askVerificationMethod(nonEmptyVerifications)
-            : nonEmptyVerifications[0];
-
-    let authTicket: string;
-    let ssoSpKey: string | null = null;
-    if (!selectedVerificationMethod || Object.keys(selectedVerificationMethod).length === 0) {
-        throw new Error('No verification method selected');
-    }
-
-    if (selectedVerificationMethod.type === 'duo_push') {
-        logger.info('Please accept the Duo push notification on your phone.');
-        ({ authTicket } = await performDuoPushVerification({ login }));
-    } else if (selectedVerificationMethod.type === 'dashlane_authenticator') {
-        logger.info('Please accept the Dashlane Authenticator push notification on your phone.');
-        ({ authTicket } = await performDashlaneAuthenticatorVerification({ login }));
-    } else if (selectedVerificationMethod.type === 'totp') {
-        const otp = await askOtp();
-        ({ authTicket } = await performTotpVerification({
-            login,
-            otp,
-        }));
-    } else if (selectedVerificationMethod.type === 'email_token') {
-        const urlEncodedLogin = encodeURIComponent(login);
-        logger.info(
-            `Please open the following URL in your browser: https://www.dashlane.com/cli-device-registration?login=${urlEncodedLogin}`
-        );
-        const token = await askToken();
-        ({ authTicket } = await performEmailTokenVerification({
-            login,
-            token,
-        }));
-    } else if (selectedVerificationMethod.type === 'sso') {
-        if (selectedVerificationMethod.ssoInfo.isNitroProvider) {
-            ({ authTicket, ssoSpKey } = await doConfidentialSSOVerification({
-                requestedLogin: login,
-            }));
-        } else {
-            ({ authTicket, ssoSpKey } = await doSSOVerification({
-                requestedLogin: login,
-                serviceProviderURL: selectedVerificationMethod.ssoInfo.serviceProviderUrl,
-            }));
-        }
-    } else {
-        throw new Error('Auth verification method not supported: ' + selectedVerificationMethod.type);
-    }
+export const registerDevice = async ({ deviceName, login }: RegisterDevice) => {
+    const { authTicket, ssoSpKey } = await getAuthenticationTickets(login);
 
     // Complete the device registration and save the result
     const completeDeviceRegistrationResponse = await completeDeviceRegistration({ login, deviceName, authTicket });
-
-    return { ...completeDeviceRegistrationResponse, ssoSpKey };
+    return { ...completeDeviceRegistrationResponse, ssoSpKey, authTicket };
 };

--- a/src/modules/database/connectAndPrepare.ts
+++ b/src/modules/database/connectAndPrepare.ts
@@ -27,6 +27,12 @@ export interface ConnectAndPrepareParams {
 
     /* Force the synchronization of the vault */
     forceSync?: boolean;
+
+    recoveryOptions?: {
+        /** Allow prompting for ARK instead of MP */
+        promptForArk?: boolean;
+        displayMasterpassword?: boolean;
+    };
 }
 
 export const connectAndPrepare = async (
@@ -36,7 +42,7 @@ export const connectAndPrepare = async (
     localConfiguration: LocalConfiguration;
     deviceConfiguration: DeviceConfiguration | null;
 }> => {
-    const { autoSync, shouldNotSaveMasterPasswordIfNoDeviceKeys, failIfNoDB, forceSync } = params;
+    const { autoSync, shouldNotSaveMasterPasswordIfNoDeviceKeys, failIfNoDB, forceSync, recoveryOptions } = params;
     const db = connect();
     db.serialize();
 
@@ -52,11 +58,10 @@ export const connectAndPrepare = async (
         process.exit(1);
     });
 
-    const localConfiguration = await getLocalConfiguration(
-        db,
-        deviceConfiguration,
-        shouldNotSaveMasterPasswordIfNoDeviceKeys
-    );
+    const localConfiguration = await getLocalConfiguration(db, deviceConfiguration, {
+        shouldNotSaveMasterPasswordIfNoDeviceKeys,
+        recoveryOptions,
+    });
 
     // if the device was created for the first time we need to get the device credentials again
     if (!deviceConfiguration) {

--- a/src/utils/dialogs.ts
+++ b/src/utils/dialogs.ts
@@ -72,6 +72,19 @@ export const askConfirmReset = async () => {
     });
     return response;
 };
+export const askConfirmRecovery = async () => {
+    const response = await confirm({
+        message: 'Doing a recovery will delete all local data from this app. Continue?',
+    });
+    return response;
+};
+
+export const askConfirmShowMp = async () => {
+    const response = await confirm({
+        message: 'Do you want to see the masterpassword that will be unlocked by this recovery key?',
+    });
+    return response;
+};
 
 export const askCredentialChoice = async (params: { matchedCredentials: VaultCredential[]; hasFilters: boolean }) => {
     const message = params.hasFilters
@@ -136,6 +149,18 @@ export const askToken = async () => {
         message: 'Please enter the code you received by email:',
         validate(input: string) {
             return /^(\d{6})$/.test(input) ? true : 'Not a valid email token';
+        },
+    });
+    return response;
+};
+
+export const askAccountRecoveryKey = async () => {
+    const response = input({
+        message: 'Please enter your account recovery key:',
+        validate(input: string) {
+            // 28 characters alpha numeric, capslock,
+            // can contain dashes between groups of 4 symbols
+            return /^(([A-Z0-9]{4}-*){7})$/.test(input) ? true : 'Not a valid recovery key';
         },
     });
     return response;


### PR DESCRIPTION
This MR brings the functionality of using ARK to log in with the CLI, optionally recovering the MP with a **recover-account** command

It will allow users who have issue with their ARK to get more information.

User XP:

```
? Doing a recovery will delete all local data from this app. Continue? yes
? Do you want to see the masterpassword that will be unlocked by this recovery key? yes
✔ The local Dashlane local storage has been reset and you have been logged out.
? Please enter your email address: <SNIPPED>
info: Please open the following URL in your browser:  <SNIPPED>
? Please enter the code you received by email: <SNIPPED>
? Please enter your account recovery key: <SNIPPED>
info: Recovered masterpassword <SNIPPED>
✔ Account recovered! you can use the CLI to export its data.
```