### PR TITLE
VACUUM command for complete cleaning of local db after logout

### DIFF
--- a/src/modules/database/reset.ts
+++ b/src/modules/database/reset.ts
@@ -14,6 +14,7 @@ export const reset = (params: ResetDB) => {
     db.prepare('DROP TABLE IF EXISTS syncUpdates').run();
     db.prepare('DROP TABLE IF EXISTS transactions').run();
     db.prepare('DROP TABLE IF EXISTS device').run();
+    db.prepare('VACUUM').run();
 
     logger.debug('Database reset');
 


### PR DESCRIPTION
Update the logout command to fully remove the data from the database. 
DROP only allow the space to be claimed while VACUUM will rebuilds the database file, removing any dropped data.