### PR TITLE
feat(enrolledDevice): add the authentication flow in the framework

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,9 +4,21 @@ export class CouldNotFindTeamCredentialsError extends Error {
     }
 }
 
+export class CouldNotFindEnrolledTeamDeviceCredentialsError extends Error {
+    constructor() {
+        super('Could not find enrolled team device credentials');
+    }
+}
+
 export class TeamCredentialsWrongFormatError extends Error {
     constructor() {
         super('Team credentials has a wrong format');
+    }
+}
+
+export class EnrolledTeamDeviceCredentialsWrongFormatError extends Error {
+    constructor() {
+        super('Enrolled team device credentials has a wrong format');
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,12 @@ import process from 'process';
 
 import { cliVersionToString, CLI_VERSION } from './cliVersion.js';
 import { rootCommands } from './commands/index.js';
-import { initDeviceCredentials, initStagingCheck, initTeamDeviceCredentials } from './utils/index.js';
+import {
+    initDeviceCredentials,
+    initEnrolledTeamDeviceCredentials,
+    initStagingCheck,
+    initTeamDeviceCredentials,
+} from './utils/index.js';
 import { errorColor, initLogger } from './logger.js';
 
 process.removeAllListeners('warning');
@@ -16,6 +21,7 @@ initLogger({ debugLevel });
 initStagingCheck();
 initTeamDeviceCredentials();
 initDeviceCredentials();
+initEnrolledTeamDeviceCredentials();
 
 const program = new Command();
 

--- a/src/modules/tunnel-api-connect/steps/sendSecureContent.ts
+++ b/src/modules/tunnel-api-connect/steps/sendSecureContent.ts
@@ -4,7 +4,7 @@ import type { SecureContentRequest, SecureContentResponse, SendSecureContentPara
 import { SecureTunnelNotInitialized, SendSecureContentDataDecryptionError } from '../errors.js';
 import type { ApiConnectInternalParams, ApiData, ApiRequestsDefault } from '../types.js';
 import { TypeCheck } from '../../typecheck/index.js';
-import { requestAppApi, requestTeamApi, requestUserApi } from '../../../requestApi.js';
+import { requestAppApi, requestEnrolledDeviceApi, requestTeamApi, requestUserApi } from '../../../requestApi.js';
 
 const verifySendSecureBodySchemaValidator = new TypeCheck<SecureContentResponse>(secureContentBodyDataSchema);
 
@@ -27,7 +27,18 @@ export const sendSecureContent = async <R extends ApiRequestsDefault>(
     const { path, clientStateIn, clientStateOut, payload: rawPayload, authentication = { type: 'app' } } = params;
     const { tunnelUuid } = apiData.clientHello;
 
-    const encryptedData = encryptData(clientStateOut, rawPayload);
+    // We assume that this section of the code will only be calling NodeWS Proxy with this authentication
+    // Inject the enrolledDeviceSecretKey when targeting NodeWS Enclave Proxy authentification
+    // to provide Nitro specific key
+    let injectedPayload = rawPayload;
+    if (authentication.type === 'enrolledDevice') {
+        injectedPayload = {
+            ...(typeof rawPayload === 'object' ? rawPayload : {}),
+            enrolledDeviceSecretKey: authentication.enrolledTeamDeviceKeys.nitroDeviceSecretKey,
+        };
+    }
+
+    const encryptedData = encryptData(clientStateOut, injectedPayload);
 
     const payload = {
         encryptedData: sodium.to_hex(encryptedData),
@@ -53,6 +64,14 @@ export const sendSecureContent = async <R extends ApiRequestsDefault>(
                 isNitroEncryptionService: true,
                 teamDeviceKeys: authentication.teamDeviceKeys,
                 teamUuid: authentication.teamUuid,
+            });
+            break;
+        case 'enrolledDevice':
+            response = await requestEnrolledDeviceApi<SecureContentResponse>({
+                path,
+                payload,
+                isNitroEncryptionService: true,
+                enrolledTeamDeviceKeys: authentication.enrolledTeamDeviceKeys,
             });
             break;
         case 'app':

--- a/src/modules/tunnel-api-connect/steps/types.ts
+++ b/src/modules/tunnel-api-connect/steps/types.ts
@@ -42,10 +42,21 @@ interface TeamDeviceAuthenticationParams {
     teamDeviceKeys: { accessKey: string; secretKey: string };
 }
 
+interface EnrolledDeviceAuthenticationParams {
+    type: 'enrolledDevice';
+    enrolledTeamDeviceKeys: {
+        nodeWSAccessKey: string;
+        nitroDeviceAccessKey: string;
+        nitroDeviceSecretKey: string;
+        secretKey: string;
+    };
+}
+
 export type AuthenticationParams =
     | AppAuthenticationParams
     | UserDeviceAuthenticationParams
-    | TeamDeviceAuthenticationParams;
+    | TeamDeviceAuthenticationParams
+    | EnrolledDeviceAuthenticationParams;
 
 export interface SendSecureContentParams<R extends ApiRequestsDefault> {
     path: R['path'];

--- a/src/requestApi.ts
+++ b/src/requestApi.ts
@@ -133,3 +133,26 @@ export const requestTeamApi = async <T>(params: RequestTeamApi): Promise<T> => {
         },
     });
 };
+
+export interface RequestEnrolledDeviceApi {
+    payload: Record<string, unknown>;
+    path: string;
+    isNitroEncryptionService?: boolean;
+    enrolledTeamDeviceKeys: {
+        nodeWSAccessKey: string;
+        nitroDeviceAccessKey: string;
+        secretKey: string;
+    };
+}
+
+export const requestEnrolledDeviceApi = async <T>(params: RequestEnrolledDeviceApi): Promise<T> => {
+    const { enrolledTeamDeviceKeys, ...otherParams } = params;
+    return requestApi({
+        ...otherParams,
+        authentication: {
+            type: 'enrolledDevice',
+            ...dashlaneApiKeys,
+            ...enrolledTeamDeviceKeys,
+        },
+    });
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,17 @@ export interface TeamDeviceCredentials {
     secretKey: string;
 }
 
+export interface EnrolledTeamDeviceCredentials {
+    // Node WS Access Key
+    nodeWSAccessKey: string;
+    // Node WS Secret Key
+    secretKey: string;
+    // Nitro Access Key
+    nitroDeviceAccessKey: string;
+    // Nitro Secret Key
+    nitroDeviceSecretKey: string;
+}
+
 export interface DeviceCredentials {
     login: string;
     accessKey: string;

--- a/src/utils/enrolledTeamDeviceCredentials.ts
+++ b/src/utils/enrolledTeamDeviceCredentials.ts
@@ -1,0 +1,45 @@
+import {
+    CouldNotFindEnrolledTeamDeviceCredentialsError,
+    EnrolledTeamDeviceCredentialsWrongFormatError,
+} from '../errors.js';
+import { EnrolledTeamDeviceCredentials } from '../types.js';
+
+let enrolledTeamDeviceCredentials: EnrolledTeamDeviceCredentials | null = null;
+
+const validateEnrolledDeviceKeys = (keys: string) =>
+    new RegExp(
+        /(DASH_EDWSA_[a-zA-Z0-9_-]{64})-(DASH_EDWSS_[a-zA-Z0-9_-]{64})-(DASH_EDNTA_[a-zA-Z0-9_-]{64})-(DASH_EDNTS_[a-zA-Z0-9_-]{64})/
+    ).exec(keys);
+
+export const initEnrolledTeamDeviceCredentials = (): EnrolledTeamDeviceCredentials | null => {
+    const { DASHLANE_ENROLLED_TEAM_DEVICE_KEYS } = process.env;
+
+    if (DASHLANE_ENROLLED_TEAM_DEVICE_KEYS) {
+        // Parsing the base64 string
+        const parsedString = Buffer.from(DASHLANE_ENROLLED_TEAM_DEVICE_KEYS, 'base64').toString('utf-8');
+        // Validating the keys
+        const parsedKeys = validateEnrolledDeviceKeys(parsedString);
+
+        if (!parsedKeys) {
+            throw new EnrolledTeamDeviceCredentialsWrongFormatError();
+        }
+
+        const [nodeWSAccessKey, secretKey, nitroDeviceAccessKey, nitroDeviceSecretKey] = parsedKeys.slice(1);
+        enrolledTeamDeviceCredentials = {
+            nodeWSAccessKey,
+            secretKey,
+            nitroDeviceAccessKey,
+            nitroDeviceSecretKey,
+        };
+    }
+
+    return enrolledTeamDeviceCredentials;
+};
+
+export const getEnrolledTeamDeviceCredentials = (): EnrolledTeamDeviceCredentials => {
+    if (!enrolledTeamDeviceCredentials) {
+        throw new CouldNotFindEnrolledTeamDeviceCredentialsError();
+    }
+
+    return enrolledTeamDeviceCredentials;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './secretTransformation.js';
 export * from './stagingCheck.js';
 export * from './strings.js';
 export * from './teamDeviceCredentials.js';
+export * from './enrolledTeamDeviceCredentials.js';


### PR DESCRIPTION
- Init the retrieval of the keys in the environement
- Add a RegEx parser based on the expected format
- Update the authentication to support EnrolledDevice type
- Inject the Nitro secret in the payload when targeting NodeWS Proxy