### PR TITLE
Update Mac Intel GH runner to macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             matrix:
                 settings:
-                    - host: macos-13
+                    - host: macos-15-intel
                       target: macos-x64
                     - host: macos-14
                       target: macos-arm64


### PR DESCRIPTION
macos-13 is deprecated https://github.com/actions/runner-images/issues/13046