### PR TITLE
fix: override TLS fingerprint to prevent Cloudflare WAF blocks on pkg binaries

### DIFF
--- a/src/utils/gotImplementation.ts
+++ b/src/utils/gotImplementation.ts
@@ -1,5 +1,6 @@
 import { RequestFunctionOptions } from '@dashlane/apiconnect-utils';
 import os from 'os';
+import https from 'node:https';
 import { got } from 'got';
 import { cliVersionToString, CLI_VERSION } from '../cliVersion';
 
@@ -19,10 +20,20 @@ const makeDashlaneClientAgent = () =>
         partner: 'dashlane',
     });
 
+// Override TLS fingerprint to avoid Cloudflare WAF blocks when running in pkg-bundled binaries.
+// pkg embeds Node.js with OpenSSL 3.0.x whose default TLS fingerprint (JA3) is blocked
+// by Cloudflare on Dashlane's authentication endpoints.
+const httpsAgent = new https.Agent({
+    ecdhCurve: 'X25519:P-256:P-384:P-521',
+    sigalgs:
+        'ecdsa_secp256r1_sha256:rsa_pss_rsae_sha256:rsa_pkcs1_sha256:ecdsa_secp384r1_sha384:rsa_pss_rsae_sha384:rsa_pkcs1_sha384:rsa_pss_rsae_sha512:rsa_pkcs1_sha512',
+});
+
 export const gotImplementation = (options: RequestFunctionOptions) => {
     const { headers, json, url } = options;
 
     return got.post(url, {
+        agent: { https: httpsAgent },
         headers: {
             ...headers,
             ...(process.env.CLOUDFLARE_SERVICE_TOKEN_ACCESS ? makeStagingCloudflareHeaders() : {}),


### PR DESCRIPTION
## Summary

- pkg embeds Node.js v22.11.0 with OpenSSL 3.0.15, whose default TLS fingerprint (JA3 `0cce74b0d9b7f8528fb2181588d23793`) is blocked by Cloudflare's WAF on Dashlane's authentication endpoints (e.g. `GetAuthenticationMethodsForDevice`)
- This causes a `403 - Sorry, you have been blocked` Cloudflare error when running `dcli sync` from a Homebrew-installed (pkg-bundled) binary
- Fix: configure a custom `https.Agent` with explicit `ecdhCurve` and `sigalgs` parameters that produce a TLS fingerprint accepted by Cloudflare

## Reproduction

```js
// From a pkg binary (node22-macos-arm64):
// WITHOUT fix → 403 Cloudflare block
// WITH fix    → 400 (normal API auth error)
```

Tested against `api.dashlane.com/v1/authentication/GetAuthenticationMethodsForDevice` from a `@yao-pkg/pkg@6.1.1` binary with `node22-macos-arm64` target.

## Test plan

- [ ] Build with `yarn build`
- [ ] Package with `yarn pkg:macos-arm`
- [ ] Run `dcli sync` from the packaged binary and confirm no Cloudflare block
- [ ] Confirm `dcli sync` still works from `node dist/index.cjs`