### PR TITLE
fix: split polling and pagination in audit logs to remove unnecessary delays

### DIFF
--- a/src/endpoints/getAuditLogs.ts
+++ b/src/endpoints/getAuditLogs.ts
@@ -84,28 +84,39 @@ export const getAuditLogs = async (params: {
     });
 
     let result: GetAuditLogQueryResultsOutput | undefined;
+    let nextToken: string | undefined;
     let logs: string[] = [];
 
     do {
-        await new Promise((resolve) => setTimeout(resolve, 2000));
         result = await api.sendSecureContent<GetAuditLogQueryResultsRequest>({
             ...api,
             path: 'cli/GetAuditLogQueryResults',
-            payload: { queryExecutionId, nextToken: result?.nextToken },
+            payload: { queryExecutionId, nextToken },
             authentication: {
                 type: 'enrolledDevice',
                 enrolledTeamDeviceKeys: enrolledTeamDeviceCredentials,
             },
         });
+
         logger.debug(`Query state: ${result.state}`);
-        if (result.state === 'SUCCEEDED') {
-            logs = logs.concat(result.results);
-        } else if (['QUEUED', 'RUNNING'].includes(result.state)) {
-            await new Promise((resolve) => setTimeout(resolve, 2000));
-        } else {
+
+        if (result.state === 'QUEUED') {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            continue;
+        }
+
+        if (result.state === 'RUNNING') {
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            continue;
+        }
+
+        if (result.state !== 'SUCCEEDED') {
             throw new Error(`Query execution did not succeed: ${result.state}`);
         }
-    } while (result.state !== 'SUCCEEDED' || result.nextToken);
+
+        logs = logs.concat(result.results);
+        nextToken = result.nextToken;
+    } while (result.state !== 'SUCCEEDED' || nextToken);
 
     return logs as unknown as GenericLog[];
 };


### PR DESCRIPTION
The query status polling and result pagination were mixed in a single loop, causing a 2s delay before every request, including pagination calls where results were already available.

Split into two distinct loops and reduce the polling interval from 2s to 500ms to better match actual query execution times (~500ms-1s)