### PR TITLE
Add `dcli status` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dashlane/cli",
-    "version": "6.2612.0",
+    "version": "6.2614.0",
     "description": "Manage your Dashlane vault through a CLI tool",
     "type": "module",
     "main": "dist/index.cjs",

--- a/src/cliVersion.ts
+++ b/src/cliVersion.ts
@@ -1,6 +1,6 @@
 import { CliVersion } from './types.js';
 
-export const CLI_VERSION: CliVersion = { major: 6, minor: 2612, patch: 0 };
+export const CLI_VERSION: CliVersion = { major: 6, minor: 2614, patch: 0 };
 export const breakingChangesVersions: CliVersion[] = [];
 
 export const cliVersionToString = (version: CliVersion): string => {

--- a/src/command-handlers/index.ts
+++ b/src/command-handlers/index.ts
@@ -11,6 +11,7 @@ export * from './read.js';
 export * from './publicAPI.js';
 export * from './secrets.js';
 export * from './secureNotes.js';
+export * from './status.js';
 export * from './sync.js';
 export * from './teamDarkWebInsightsReport.js';
 export * from './teamLogs.js';

--- a/src/command-handlers/status.ts
+++ b/src/command-handlers/status.ts
@@ -1,0 +1,68 @@
+import Database from 'better-sqlite3';
+import { Entry } from '@napi-rs/keyring';
+import fs from 'fs';
+
+import { connect, getDatabasePath } from '../modules/database/connect.js';
+import { DeviceConfiguration } from '../types.js';
+import { logger } from '../logger.js';
+
+const SERVICE = 'dashlane-cli';
+
+const isVaultLocked = (deviceConfiguration: DeviceConfiguration): boolean => {
+    // If the master password should not be saved, the vault is always "locked"
+    if (deviceConfiguration.shouldNotSaveMasterPassword) {
+        return true;
+    }
+
+    // If no encrypted master password is stored in the DB, the vault is locked
+    if (!deviceConfiguration.masterPasswordEncrypted) {
+        return true;
+    }
+
+    // Try to retrieve the local key from the OS keychain
+    try {
+        const entry = new Entry(SERVICE, deviceConfiguration.login);
+        const localKeyEncoded = entry.getPassword();
+        if (localKeyEncoded) {
+            return false;
+        }
+    } catch {
+        logger.error('Unable to access the keychain to determine vault lock status');
+        return true;
+    }
+
+    return true;
+};
+
+export const runStatus = (): void => {
+    const dbPath = getDatabasePath();
+    if (!fs.existsSync(dbPath)) {
+        logger.content('Logged in: no');
+        return;
+    }
+
+    let db: Database.Database;
+    try {
+        db = connect();
+    } catch {
+        logger.error('Unable to access the database to determine login status');
+        return;
+    }
+
+    try {
+        const deviceConfiguration = db.prepare('SELECT * FROM device LIMIT 1').get() as DeviceConfiguration | undefined;
+
+        if (!deviceConfiguration) {
+            logger.content('Logged in: no');
+            return;
+        }
+
+        const locked = isVaultLocked(deviceConfiguration);
+
+        logger.content(`Logged in: yes`);
+        logger.content(`Login: ${deviceConfiguration.login}`);
+        logger.content(`Locked: ${locked ? 'yes' : 'no'}`);
+    } finally {
+        db.close();
+    }
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,7 @@ import {
     runExec,
     runBackup,
     runSecret,
+    runStatus,
 } from '../command-handlers/index.js';
 
 export const rootCommands = (params: { program: Command }) => {
@@ -24,6 +25,8 @@ export const rootCommands = (params: { program: Command }) => {
         .alias('s')
         .description('Manually synchronize the local vault with Dashlane')
         .action(runSync);
+
+    program.command('status').description('Get the status of the CLI (logged in, locked, etc.)').action(runStatus);
 
     program
         .command('read')


### PR DESCRIPTION
## Add `dcli status` command

### Problem

Users who integrate `dcli` into scripts (e.g. password autofill in qutebrowser) currently have no lightweight way to check whether the CLI is logged in and whether the vault is unlocked. They resort to running commands like `dcli sync` or `dcli password` and parsing their output or exit codes, which results in redundant API calls and can trigger rate limits.

### Solution

This MR adds a new top-level `dcli status` command that reports the current authentication and lock state of the CLI **without making any API calls**. It only reads from the local SQLite database and the OS keychain.

#### Example output

```
~> dcli status
Logged in: yes
Login: user@example.com
Locked: no
```

If not logged in:

```
~> dcli status
Logged in: no
```

### How it works

1. **Logged in** — Checks whether the local database file exists and contains a registered device configuration.
2. **Locked** — Determines lock state by checking:
   - Whether `shouldNotSaveMasterPassword` is set (always considered locked — user must type password each time).
   - Whether an encrypted master password is stored in the database.
   - Whether the local key can be retrieved from the OS keychain (`@napi-rs/keyring`).

All checks are purely local — no network requests, no authentication prompts, no vault decryption.

### Files changed

| File | Change |
|---|---|
| `src/command-handlers/status.ts` | **New** — `runStatus` handler and `isVaultLocked` helper |
| `src/command-handlers/index.ts` | Added `status` module export |
| `src/commands/index.ts` | Registered `dcli status` as a top-level command |

### Testing

- Run `dcli status` when logged out → outputs `Logged in: no`
- Run `dcli status` when logged in and unlocked → outputs `Logged in: yes`, `Login: <email>`, `Locked: no`
- Run `dcli lock` then `dcli status` → outputs `Locked: yes`
- Verify no network calls are made (e.g. via `--debug` flag or network monitoring)

Closes: #315 
