### PR TITLE
Direct Master Password prompt to stderr

### DIFF
--- a/src/utils/dialogs.ts
+++ b/src/utils/dialogs.ts
@@ -23,7 +23,7 @@ export const askMasterPassword = async (): Promise<string> => {
         validate(input: string) {
             return input.length ? true : 'Master password cannot be empty';
         },
-    });
+    }, {output: process.stderr});
     return response;
 };
 


### PR DESCRIPTION
Redirects the master password prompt to stderr so that it can be used within scripts
Fixes #393 