### PR TITLE
Feature/opaque

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
         "@napi-rs/clipboard": "^1.1.2",
         "@napi-rs/keyring": "^1.1.6",
         "@node-rs/argon2": "^2.0.0",
+        "@serenity-kit/opaque": "^1.1.0",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "better-sqlite3": "^11.5.0",

--- a/src/endpoints/completeOpaqueMPLogin.ts
+++ b/src/endpoints/completeOpaqueMPLogin.ts
@@ -1,0 +1,27 @@
+import { requestUserApi } from '../requestApi.js';
+import { DeviceCredentials } from '../types.js';
+
+interface completeOpaqueMPLoginParams {
+    deviceCredentials: DeviceCredentials;
+    finishLoginRequest: string;
+    opaqueMPLoginFlowId: string;
+}
+
+export interface completeOpaqueMPLoginOutput {
+    loginResponse: string;
+    opaqueMPLoginFlowId: string;
+}
+
+export const completeOpaqueMPLogin = (params: completeOpaqueMPLoginParams) =>
+    requestUserApi<completeOpaqueMPLoginOutput>({
+        path: 'authentication/CompleteOpaqueMPLogin',
+        payload: {
+            finishLoginRequest: params.finishLoginRequest,
+            opaqueMPLoginFlowId: params.opaqueMPLoginFlowId,
+        },
+        login: params.deviceCredentials.login,
+        deviceKeys: {
+            accessKey: params.deviceCredentials.accessKey,
+            secretKey: params.deviceCredentials.secretKey,
+        },
+    });

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,5 +1,6 @@
 export * from './completeDeviceRegistration.js';
 export * from './completeLoginWithAuthTicket.js';
+export * from './completeOpaqueMPLogin.js';
 export * from './createPublicAPIKey.js';
 export * from './deactivateDevices.js';
 export * from './getAuditLogs.js';
@@ -12,4 +13,5 @@ export * from './getTeamReport.js';
 export * from './listDevices.js';
 export * from './listPublicAPIKeys.js';
 export * from './performTokenVerification.js';
+export * from './requestOpaqueMPLogin.js';
 export * from './revokePublicAPIKey.js';

--- a/src/endpoints/requestOpaqueMPLogin.ts
+++ b/src/endpoints/requestOpaqueMPLogin.ts
@@ -1,0 +1,25 @@
+import { requestUserApi } from '../requestApi.js';
+import { DeviceCredentials } from '../types.js';
+
+interface requestOpaqueMPLoginParams {
+    deviceCredentials: DeviceCredentials;
+    loginRequest: string;
+}
+
+export interface requestOpaqueMPLoginOutput {
+    loginResponse: string;
+    opaqueMPLoginFlowId: string;
+}
+
+export const requestOpaqueMPLogin = (params: requestOpaqueMPLoginParams) =>
+    requestUserApi<requestOpaqueMPLoginOutput>({
+        path: 'authentication/RequestOpaqueMPLogin',
+        payload: {
+            loginRequest: params.loginRequest,
+        },
+        login: params.deviceCredentials.login,
+        deviceKeys: {
+            accessKey: params.deviceCredentials.accessKey,
+            secretKey: params.deviceCredentials.secretKey,
+        },
+    });

--- a/src/modules/auth/opaque/constants.ts
+++ b/src/modules/auth/opaque/constants.ts
@@ -1,0 +1,12 @@
+export const serverConfig = {
+    serverIdentifier: 'api.dashlane.com',
+    serverPublicKey: 'rjMOj0DcV7XqxiaS2vbw9s1ri4MwcbooW-ztusqFFmk',
+};
+
+export const KEY_STRETCHING_CONFIG = {
+    v1: {
+        iterations: 3,
+        memory: 65_536,
+        parallelism: 4,
+    },
+};

--- a/src/modules/auth/opaque/database.ts
+++ b/src/modules/auth/opaque/database.ts
@@ -1,0 +1,16 @@
+import { Database } from 'better-sqlite3';
+
+/**
+ * returns true if the device is already mark as proven in the local database
+ */
+export const isDeviceProven = (db: Database, login: string): boolean => {
+    const isDeviceProven = db.prepare('SELECT 1 FROM proven_devices WHERE login = ?').bind(login).get();
+    return !!isDeviceProven;
+};
+
+/**
+ * Marks the device as proven in the local database
+ */
+export const markDeviceAsProven = (db: Database, login: string) => {
+    return db.prepare('INSERT INTO proven_devices VALUES(?)').bind(login).run();
+};

--- a/src/modules/auth/opaque/utils.ts
+++ b/src/modules/auth/opaque/utils.ts
@@ -1,0 +1,80 @@
+import * as opaque from '@serenity-kit/opaque';
+import { Database } from 'better-sqlite3';
+import { requestOpaqueMPLoginOutput, requestOpaqueMPLogin, completeOpaqueMPLogin } from '../../../endpoints';
+import { DashlaneApiError } from '../../../requestApi';
+import { DeviceCredentials } from '../../../types';
+import { isDeviceProven, markDeviceAsProven } from './database';
+import { serverConfig, KEY_STRETCHING_CONFIG } from './constants';
+
+/**
+ * Attempt an Opaque login for the user and mark the device as proven on success
+ * Ignore if already proven. Mark the device as proven when needed
+ * Throw if error while login
+ */
+export const loginWithOpaque = async (deviceInfo: DeviceCredentials, db: Database) => {
+    // If the device is already proven, it doesn't need to go through
+    // the opaque login flow
+    if (isDeviceProven(db, deviceInfo.login)) {
+        return;
+    }
+
+    const loginResult = opaque.client.startLogin({
+        password: deviceInfo.masterPassword,
+    });
+
+    let requestLoginResult: requestOpaqueMPLoginOutput | undefined;
+    try {
+        requestLoginResult = await requestOpaqueMPLogin({
+            deviceCredentials: deviceInfo,
+            loginRequest: loginResult.startLoginRequest,
+        });
+    } catch (error) {
+        const { code } = error as DashlaneApiError;
+        if (['OPAQUE_MASTER_PASSWORD_ENDPOINT_DISABLED', 'OPAQUE_MASTER_PASSWORD_NOT_REGISTERED'].includes(code)) {
+            // The flow is stopped if the endpoint is disabled or if Opaque is not setup for this user
+            // The device is not marked as PROVEN though as it has not been through the full Opaque flow
+            return;
+        }
+
+        throw new Error(`Error while verifying the master password (${code})`);
+    }
+
+    const finishLoginResult = opaque.client.finishLogin({
+        clientLoginState: loginResult.clientLoginState,
+        loginResponse: requestLoginResult.loginResponse,
+        password: deviceInfo.masterPassword,
+        identifiers: { server: serverConfig.serverIdentifier },
+        keyStretching: { 'argon2id-custom': KEY_STRETCHING_CONFIG.v1 },
+    });
+
+    if (
+        !finishLoginResult?.finishLoginRequest ||
+        finishLoginResult.serverStaticPublicKey !== serverConfig.serverPublicKey
+    ) {
+        throw new Error(`Error while verifying the master password`);
+    }
+
+    try {
+        await completeOpaqueMPLogin({
+            deviceCredentials: deviceInfo,
+            finishLoginRequest: finishLoginResult?.finishLoginRequest,
+            opaqueMPLoginFlowId: requestLoginResult.opaqueMPLoginFlowId,
+        });
+    } catch (error) {
+        const { code } = error as DashlaneApiError;
+        // If the endpoint is disabled, we ignore the error but we don't mark the device as PROVEN
+        if (['OPAQUE_MASTER_PASSWORD_ENDPOINT_DISABLED'].includes(code)) {
+            return;
+        }
+
+        // If one of those errors are returned, an error is raised
+        if (['LOGIN_REQUEST_NOT_FOUND', 'OPAQUE_LOGIN_FAILED', 'INVALID_LOGIN_FLOW_ID'].includes(code)) {
+            throw new Error(`Error while verifying the master password`);
+        }
+
+        // Note: the error case DEVICE_ALREADY_PROVEN is not handled here to be mark the device as proven afterwards
+    }
+
+    // The device is marked as proven because the flow went well or returned a DEVICE_ALREADY_PROVEN error
+    markDeviceAsProven(db, deviceInfo.login);
+};

--- a/src/modules/crypto/keychainManager.ts
+++ b/src/modules/crypto/keychainManager.ts
@@ -14,6 +14,7 @@ import { askEmailAddress, askMasterPassword } from '../../utils/dialogs.js';
 import { get2FAStatusUnauthenticated } from '../../endpoints/get2FAStatusUnauthenticated.js';
 import { getEnvDeviceCredentials, hasEnvDeviceCredentials } from '../../utils/index.js';
 import { logger } from '../../logger.js';
+import { loginWithOpaque } from '../auth/opaque/utils.js';
 
 const SERVICE = 'dashlane-cli';
 
@@ -120,6 +121,17 @@ const getLocalConfigurationWithoutDB = async (
     } else {
         masterPassword = masterPasswordEnv ?? (await askMasterPassword());
 
+        // An opaque login is made before going further to make sure the password is correct
+        await loginWithOpaque(
+            {
+                accessKey: deviceAccessKey,
+                login,
+                masterPassword,
+                secretKey: deviceSecretKey,
+            },
+            db
+        );
+
         // In case of OTP2
         if (type === 'totp_login' && serverKey) {
             serverKeyEncrypted = encryptAesCbcHmac256(localKey, Buffer.from(serverKey));
@@ -205,6 +217,19 @@ const getLocalConfigurationWithoutKeychain = async (
         await decrypt(deviceConfiguration.secretKeyEncrypted, { type: 'alreadyComputed', symmetricKey: localKey })
     ).toString('hex');
 
+    // we do an Opaque Login to mark the device as PROVEN even if the MP was used correctly to retrieve the secret key
+    // this is needed when the user made the device registration at a time when the Opaque Enveloppe was not set yet but now there
+    // is an Opaque Enveloppe so the device should be marked as PROVEN as soon as the MP is verifed through Opaque
+    await loginWithOpaque(
+        {
+            login,
+            secretKey,
+            accessKey: deviceConfiguration.accessKey,
+            masterPassword,
+        },
+        db
+    );
+
     if (!deviceConfiguration.shouldNotSaveMasterPassword) {
         setLocalKey(login, localKey, (errorMessage) => {
             logger.warn(`Unable to reach OS keychain because of error: "${errorMessage}". \
@@ -254,6 +279,11 @@ export const replaceMasterPassword = async (
     }
 
     newMasterPassword += await askMasterPassword();
+
+    // notes : No Opaque Login is performed here as this code is not  reached if the user has an Opaque Enveloppe
+    // Indeed, this code is only reached if the user synced the data with a wrong MP which won't be possible as soon as an Opaque
+    // Enveloppe is set for an user.
+    // Consider removing this function and the review the check for the setting where it is used when Opaque is fully rolled-out.
 
     const derivate = await getDerivateUsingParametersFromEncryptedData(
         newMasterPassword,

--- a/src/modules/database/prepare.ts
+++ b/src/modules/database/prepare.ts
@@ -40,6 +40,11 @@ export const prepareDB = (params: PrepareDB): DeviceConfiguration | null => {
             serverKeyEncrypted VARCHAR(255)
         );`
     ).run();
+    db.prepare(
+        `CREATE TABLE IF NOT EXISTS proven_devices (
+            login VARCHAR(255) PRIMARY KEY
+        );`
+    ).run();
 
     return db.prepare('SELECT * FROM device LIMIT 1').get() as DeviceConfiguration | null;
 };

--- a/src/modules/database/reset.ts
+++ b/src/modules/database/reset.ts
@@ -14,6 +14,7 @@ export const reset = (params: ResetDB) => {
     db.prepare('DROP TABLE IF EXISTS syncUpdates').run();
     db.prepare('DROP TABLE IF EXISTS transactions').run();
     db.prepare('DROP TABLE IF EXISTS device').run();
+    db.prepare('DROP TABLE IF EXISTS proven_devices').run();
     db.prepare('VACUUM').run();
 
     logger.debug('Database reset');

--- a/src/requestApi.ts
+++ b/src/requestApi.ts
@@ -15,7 +15,7 @@ interface DashlaneApiErrorResponse {
     errors: { type: string; code: string; message: string }[];
 }
 
-class DashlaneApiError extends Error {
+export class DashlaneApiError extends Error {
     public code: string; // ex "invalid_otp_already_used"
     public type: string; // ex "business_error"
     constructor(details: DashlaneApiErrorResponse['errors'][0]) {
@@ -65,6 +65,15 @@ const requestApi = async <T>(params: RequestApi): Promise<T> => {
     }
 
     if (response.statusCode !== 200) {
+        let details;
+        try {
+            details = (JSON.parse(response.body) as DashlaneApiErrorResponse).errors[0];
+        } catch (parseError) {
+            logger.debug('Failed to parse error response', parseError);
+        }
+        if (details) {
+            throw new DashlaneApiError(details);
+        }
         throw new Error('Server responded an error : ' + response.body);
     }
     return (JSON.parse(response.body) as { data: T }).data;

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,7 @@ __metadata:
     "@napi-rs/clipboard": "npm:^1.1.2"
     "@napi-rs/keyring": "npm:^1.1.6"
     "@node-rs/argon2": "npm:^2.0.0"
+    "@serenity-kit/opaque": "npm:^1.1.0"
     "@types/async": "npm:^3.2.24"
     "@types/better-sqlite3": "npm:^7.6.11"
     "@types/chai": "npm:^5.0.1"
@@ -1349,6 +1350,15 @@ __metadata:
   version: 0.4.1
   resolution: "@sec-ant/readable-stream@npm:0.4.1"
   checksum: 10/aac89581652ac85debe7c5303451c2ebf8bf25ca25db680e4b9b73168f6940616d9a4bbe3348981827b1159b14e2f2e6af4b7bd5735cac898c12d5c51909c102
+  languageName: node
+  linkType: hard
+
+"@serenity-kit/opaque@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@serenity-kit/opaque@npm:1.1.0"
+  bin:
+    opaque: bin/index.js
+  checksum: 10/6ddddd2857b86b564c83ba1eef785fa01941442b32deac2d4dfdccc6568a10411192222b6e881767af7556270c05fd1df6a790f1412fc51a9c223c69965232ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This MR : 
- adds the dependency to `@serenity-kit/opaque`
- adds the endpoints definition for the opaque flow 
- changes the RequestAPI error forwarding mechanism to forward the 400 error to the caller 
- adds a `proven_devices` table in the database to store the fact that the device is proven
- adds the opaque login flow on device registration and device unlocking 