### PR TITLE
Update authentication documentation for user enumeration changes

### DIFF
--- a/documentation/pages/personal/authentication.mdx
+++ b/documentation/pages/personal/authentication.mdx
@@ -9,7 +9,7 @@ dcli sync
 ```
 
 Authenticating to your personal vault requires your email.
-You will be then asked to validate a second factor to register the CLI to your account.
+You’ll then be asked for multiple tokens to validate a second factor to register the Dashlane CLI to your account. If you’ve enabled 2FA on your account, make sure to use the token from your authentication app, as you won’t receive a token by email.
 
 ## Supported primary authentication methods
 


### PR DESCRIPTION
This PR update the authentication documentation to mention the multiple tokens needed when doing a new device registration